### PR TITLE
[FRONT] 팝업 스토어 조회 API 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	runtimeOnly("com.h2database:h2")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	implementation("org.springdoc:springdoc-openapi-ui:1.6.11")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/org/waitforme/backend/api/ShopController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/ShopController.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.data.domain.PageRequest
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.waitforme.backend.model.response.shop.ShopDetailResponse
 import org.waitforme.backend.model.response.shop.ShopListResponse
@@ -13,7 +14,7 @@ import org.waitforme.backend.service.ShopService
 
 @RestController
 @Tag(name = "POP UP 스토어")
-
+@RequestMapping("/v1/shop")
 class ShopController(
     private val shopService: ShopService
 ) {

--- a/src/main/kotlin/org/waitforme/backend/api/ShopController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/ShopController.kt
@@ -18,7 +18,7 @@ class ShopController(
     private val shopService: ShopService
 ) {
     @GetMapping("")
-    suspend fun getShopList(
+    fun getShopList(
         @Parameter(name = "page", description = "0페이지부터 시작", `in` = ParameterIn.QUERY)
         page: Int? = 0,
         @Parameter(name = "size", description = "1페이지 당 크기", `in` = ParameterIn.QUERY)
@@ -27,7 +27,7 @@ class ShopController(
         shopService.getShopList(PageRequest.of(page ?: 0, size ?: 10))
 
     @GetMapping("/{id}")
-    suspend fun getShopDetail(
+    fun getShopDetail(
         @Parameter(name = "id", description = "팝업 ID", `in` = ParameterIn.PATH)
         @PathVariable
         id: Int

--- a/src/main/kotlin/org/waitforme/backend/api/ShopController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/ShopController.kt
@@ -1,0 +1,36 @@
+package org.waitforme.backend.api
+
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.PageRequest
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+import org.waitforme.backend.model.response.shop.ShopDetailResponse
+import org.waitforme.backend.model.response.shop.ShopListResponse
+import org.waitforme.backend.service.ShopService
+
+@RestController
+@Tag(name = "POP UP 스토어")
+
+class ShopController(
+    private val shopService: ShopService
+) {
+    @GetMapping("")
+    suspend fun getShopList(
+        @Parameter(name = "page", description = "0페이지부터 시작", `in` = ParameterIn.QUERY)
+        page: Int? = 0,
+        @Parameter(name = "size", description = "1페이지 당 크기", `in` = ParameterIn.QUERY)
+        size: Int? = 10,
+    ): List<ShopListResponse> =
+        shopService.getShopList(PageRequest.of(page ?: 0, size ?: 10))
+
+    @GetMapping("/{id}")
+    suspend fun getShopDetail(
+        @Parameter(name = "id", description = "팝업 ID", `in` = ParameterIn.PATH)
+        @PathVariable
+        id: Int
+    ): ShopDetailResponse =
+        shopService.getShopDetail(id)
+}

--- a/src/main/kotlin/org/waitforme/backend/common/BaseEntity.kt
+++ b/src/main/kotlin/org/waitforme/backend/common/BaseEntity.kt
@@ -1,0 +1,21 @@
+package org.waitforme.backend.common
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import javax.persistence.Column
+import javax.persistence.EntityListeners
+import javax.persistence.MappedSuperclass
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseEntity {
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected var createdAt: LocalDateTime = LocalDateTime.MIN
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected var updatedAt: LocalDateTime = LocalDateTime.MIN
+}

--- a/src/main/kotlin/org/waitforme/backend/entity/shop/Shop.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/shop/Shop.kt
@@ -1,0 +1,29 @@
+package org.waitforme.backend.entity.shop
+
+import org.waitforme.backend.common.BaseEntity
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import javax.persistence.*
+
+@Table(name = "shop")
+@Entity
+data class Shop(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Int = 0,
+    val userId: Int,
+    var registrationNumber: String,
+    var category: String,
+    var name: String,
+    var startedAt: LocalDate,
+    var endedAt: LocalDate,
+    var openedAt: LocalTime,
+    var closedAt: LocalTime,
+    var address: String,
+    var description: String? = null,
+    var snsInfo: String = "{}",
+    var isDeleted: Boolean = false,
+    var isShow: Boolean = true,
+    var deletedAt: LocalDateTime
+) : BaseEntity()

--- a/src/main/kotlin/org/waitforme/backend/entity/shop/ShopImage.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/shop/ShopImage.kt
@@ -2,9 +2,6 @@ package org.waitforme.backend.entity.shop
 
 import org.waitforme.backend.common.BaseEntity
 import org.waitforme.backend.enums.ImageType
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 import javax.persistence.*
 
 @Table(name = "shop_image")

--- a/src/main/kotlin/org/waitforme/backend/entity/shop/ShopImage.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/shop/ShopImage.kt
@@ -1,0 +1,22 @@
+package org.waitforme.backend.entity.shop
+
+import org.waitforme.backend.common.BaseEntity
+import org.waitforme.backend.enums.ImageType
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import javax.persistence.*
+
+@Table(name = "shop_image")
+@Entity
+data class ShopImage(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Int = 0,
+    val shopId: Int,
+    @Enumerated(value = EnumType.STRING)
+    var imageType: ImageType,
+    var imagePath: String,
+    var orderNo: Int = 1,
+    var isShow: Boolean = true,
+): BaseEntity()

--- a/src/main/kotlin/org/waitforme/backend/enums/ImageType.kt
+++ b/src/main/kotlin/org/waitforme/backend/enums/ImageType.kt
@@ -1,0 +1,6 @@
+package org.waitforme.backend.enums
+
+enum class ImageType {
+    MAIN,
+    DETAIL
+}

--- a/src/main/kotlin/org/waitforme/backend/enums/SnsType.kt
+++ b/src/main/kotlin/org/waitforme/backend/enums/SnsType.kt
@@ -1,0 +1,5 @@
+package org.waitforme.backend.enums
+
+enum class SnsType {
+    TWITTER, INSTAGRAM, FACEBOOK, KAKAO
+}

--- a/src/main/kotlin/org/waitforme/backend/model/dto/ShopListResultDto.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/dto/ShopListResultDto.kt
@@ -1,0 +1,7 @@
+package org.waitforme.backend.model.dto
+
+data class ShopListResultDto(
+    val id: Int,
+    val name: String,
+    val imagePath: String
+)

--- a/src/main/kotlin/org/waitforme/backend/model/dto/SnsInfo.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/dto/SnsInfo.kt
@@ -1,0 +1,8 @@
+package org.waitforme.backend.model.dto
+
+import org.waitforme.backend.enums.SnsType
+
+data class SnsInfo(
+    val snsType: SnsType,
+    val snsId: String
+)

--- a/src/main/kotlin/org/waitforme/backend/model/response/shop/ShopDetailResponse.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/response/shop/ShopDetailResponse.kt
@@ -1,0 +1,32 @@
+package org.waitforme.backend.model.response.shop
+
+import org.waitforme.backend.entity.shop.Shop
+import org.waitforme.backend.model.dto.SnsInfo
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class ShopDetailResponse(
+    val title: String,
+    val description: String?,
+    val imageInfo: List<ShopImageResponse>,
+    val startedAt: LocalDate,
+    val endedAt: LocalDate,
+    val openedAt: LocalTime,
+    val closedAt: LocalTime,
+    val address: String,
+    val snsInfo: List<SnsInfo> = listOf(),
+    val isFavorite: Boolean = false,
+    val isReserved: Boolean = false,
+)
+
+fun Shop.toDetailResponse(imageInfo: List<ShopImageResponse>) = ShopDetailResponse(
+    title = name,
+    description = description,
+    imageInfo = imageInfo,
+    startedAt = startedAt,
+    endedAt = endedAt,
+    openedAt = openedAt,
+    closedAt = closedAt,
+    address = address,
+//    snsInfo = snsInfo.toInfo(),
+)

--- a/src/main/kotlin/org/waitforme/backend/model/response/shop/ShopImageResponse.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/response/shop/ShopImageResponse.kt
@@ -1,0 +1,14 @@
+package org.waitforme.backend.model.response.shop
+
+import org.waitforme.backend.entity.shop.ShopImage
+import org.waitforme.backend.enums.ImageType
+
+data class ShopImageResponse(
+    val type: ImageType,
+    val path: String
+)
+
+fun ShopImage.toResponse() = ShopImageResponse(
+    type = imageType,
+    path = imagePath
+)

--- a/src/main/kotlin/org/waitforme/backend/model/response/shop/ShopListResponse.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/response/shop/ShopListResponse.kt
@@ -1,0 +1,18 @@
+package org.waitforme.backend.model.response.shop
+
+import org.waitforme.backend.entity.shop.Shop
+import org.waitforme.backend.entity.shop.ShopImage
+import org.waitforme.backend.model.dto.ShopListResultDto
+import javax.swing.border.TitledBorder
+
+data class ShopListResponse(
+    val id: Int,
+    val title: String,
+    val imagePath: String
+)
+
+fun ShopListResultDto.toResponse() = ShopListResponse(
+    id = id,
+    title = name,
+    imagePath = imagePath
+)

--- a/src/main/kotlin/org/waitforme/backend/repository/shop/ShopImageRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/shop/ShopImageRepository.kt
@@ -1,0 +1,9 @@
+package org.waitforme.backend.repository.shop
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+import org.waitforme.backend.entity.shop.ShopImage
+
+@Repository
+interface ShopImageRepository : CoroutineCrudRepository<ShopImage, Int> {
+}

--- a/src/main/kotlin/org/waitforme/backend/repository/shop/ShopImageRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/shop/ShopImageRepository.kt
@@ -6,4 +6,7 @@ import org.waitforme.backend.entity.shop.ShopImage
 
 @Repository
 interface ShopImageRepository : CoroutineCrudRepository<ShopImage, Int> {
+
+    suspend fun findByShopIdAndIsShowOrderByOrderNo(shopId: Int, isShow: Boolean = true): List<ShopImage>
+
 }

--- a/src/main/kotlin/org/waitforme/backend/repository/shop/ShopImageRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/shop/ShopImageRepository.kt
@@ -1,12 +1,12 @@
 package org.waitforme.backend.repository.shop
 
-import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 import org.waitforme.backend.entity.shop.ShopImage
 
 @Repository
-interface ShopImageRepository : CoroutineCrudRepository<ShopImage, Int> {
+interface ShopImageRepository : CrudRepository<ShopImage, Int> {
 
-    suspend fun findByShopIdAndIsShowOrderByOrderNo(shopId: Int, isShow: Boolean = true): List<ShopImage>
+    fun findByShopIdAndIsShowOrderByOrderNo(shopId: Int, isShow: Boolean = true): List<ShopImage>
 
 }

--- a/src/main/kotlin/org/waitforme/backend/repository/shop/ShopRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/shop/ShopRepository.kt
@@ -2,30 +2,30 @@ package org.waitforme.backend.repository.shop
 
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 import org.waitforme.backend.entity.shop.Shop
 import org.waitforme.backend.model.dto.ShopListResultDto
 import java.time.LocalDate
 
 @Repository
-interface ShopRepository : CoroutineCrudRepository<Shop, Int> {
+interface ShopRepository : CrudRepository<Shop, Int> {
 
     @Query("SELECT s.id, s.name, si.imagePath " +
             "FROM Shop as s " +
             "INNER JOIN ShopImage as si ON s.id = si.shopId " +
-            "WHERE s.startedAt < :openedAt " +
-            "AND s.endedAt >= :endedAt " +
-            "AND s.isShow = :isShow " +
+            "WHERE s.startedAt < ?1 " +
+            "AND s.endedAt >= ?2 " +
+            "AND s.isShow = ?3 " +
             "AND si.imageType = 'MAIN' " +
             "AND s.isDeleted = false "
     )
-    suspend fun findShopList(
+    fun findShopList(
         startedAt: LocalDate,
         endedAt: LocalDate,
         isShow: Boolean = true,
         pageable: Pageable
     ): List<ShopListResultDto>
 
-    suspend fun findByIdAndIsShow(id: Int, isShow: Boolean = true): Shop?
+    fun findByIdAndIsShow(id: Int, isShow: Boolean = true): Shop?
 }

--- a/src/main/kotlin/org/waitforme/backend/repository/shop/ShopRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/shop/ShopRepository.kt
@@ -1,9 +1,31 @@
 package org.waitforme.backend.repository.shop
 
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Repository
 import org.waitforme.backend.entity.shop.Shop
+import org.waitforme.backend.model.dto.ShopListResultDto
+import java.time.LocalDate
 
 @Repository
 interface ShopRepository : CoroutineCrudRepository<Shop, Int> {
+
+    @Query("SELECT s.id, s.name, si.imagePath " +
+            "FROM Shop as s " +
+            "INNER JOIN ShopImage as si ON s.id = si.shopId " +
+            "WHERE s.startedAt < :openedAt " +
+            "AND s.endedAt >= :endedAt " +
+            "AND s.isShow = :isShow " +
+            "AND si.imageType = 'MAIN' " +
+            "AND s.isDeleted = false "
+    )
+    suspend fun findShopList(
+        startedAt: LocalDate,
+        endedAt: LocalDate,
+        isShow: Boolean = true,
+        pageable: Pageable
+    ): List<ShopListResultDto>
+
+    suspend fun findByIdAndIsShow(id: Int, isShow: Boolean = true): Shop?
 }

--- a/src/main/kotlin/org/waitforme/backend/repository/shop/ShopRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/shop/ShopRepository.kt
@@ -1,0 +1,9 @@
+package org.waitforme.backend.repository.shop
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+import org.waitforme.backend.entity.shop.Shop
+
+@Repository
+interface ShopRepository : CoroutineCrudRepository<Shop, Int> {
+}

--- a/src/main/kotlin/org/waitforme/backend/service/ShopService.kt
+++ b/src/main/kotlin/org/waitforme/backend/service/ShopService.kt
@@ -1,0 +1,36 @@
+package org.waitforme.backend.service
+
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.waitforme.backend.model.response.shop.ShopDetailResponse
+import org.waitforme.backend.model.response.shop.ShopListResponse
+import org.waitforme.backend.model.response.shop.toDetailResponse
+import org.waitforme.backend.model.response.shop.toResponse
+import org.waitforme.backend.repository.shop.ShopImageRepository
+import org.waitforme.backend.repository.shop.ShopRepository
+import org.webjars.NotFoundException
+import java.time.LocalDate
+
+
+@Service
+class ShopService(
+    private val shopRepository: ShopRepository,
+    private val shopImageRepository: ShopImageRepository,
+) {
+    suspend fun getShopList(pageRequest: PageRequest): List<ShopListResponse> {
+        val now = LocalDate.now()
+        return shopRepository.findShopList(
+            startedAt = now,
+            endedAt = now,
+            pageable = pageRequest
+        ).map { it.toResponse() }
+    }
+
+    suspend fun getShopDetail(id: Int): ShopDetailResponse {
+        return shopRepository.findByIdAndIsShow(id)?.let { shop ->
+            val images = shopImageRepository.findByShopIdAndIsShowOrderByOrderNo(shop.id)
+                .map { it.toResponse() }
+            shop.toDetailResponse(images)
+        } ?: throw NotFoundException("팝업을 찾을 수 없습니다.")
+    }
+}

--- a/src/main/kotlin/org/waitforme/backend/service/ShopService.kt
+++ b/src/main/kotlin/org/waitforme/backend/service/ShopService.kt
@@ -17,7 +17,7 @@ class ShopService(
     private val shopRepository: ShopRepository,
     private val shopImageRepository: ShopImageRepository,
 ) {
-    suspend fun getShopList(pageRequest: PageRequest): List<ShopListResponse> {
+    fun getShopList(pageRequest: PageRequest): List<ShopListResponse> {
         val now = LocalDate.now()
         return shopRepository.findShopList(
             startedAt = now,
@@ -26,7 +26,7 @@ class ShopService(
         ).map { it.toResponse() }
     }
 
-    suspend fun getShopDetail(id: Int): ShopDetailResponse {
+    fun getShopDetail(id: Int): ShopDetailResponse {
         return shopRepository.findByIdAndIsShow(id)?.let { shop ->
             val images = shopImageRepository.findByShopIdAndIsShowOrderByOrderNo(shop.id)
                 .map { it.toResponse() }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 80 # 내장 톰캣 포트번호
+  port: 8080 # 내장 톰캣 포트번호
 
 spring:
   # H2 Database 설정


### PR DESCRIPTION
- 팝업 스토어 리스트 조회 API
- 팝업 스토어 상세 조회 API
추가

- 스웨거 설정 추가

위의 API는 추후 FRONT와 협의 하에 수정할 예정이라 간단하게 만들었습니다.

TO-BE
- 백오피스 용으로 스웨거에서만 사용할
  - 팝업 스토어 생성 API
  - 팝업 스토어 수정 API
  - 팝업 스토어 노출/비노출 API
  를 추후 추가할 예정입니다.

@bimppap님 @effiRin님 리뷰 부탁드립니다!