### PR TITLE
[FRONT] 북마크 API 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 	kotlin("jvm") version "1.6.21"
 	kotlin("plugin.spring") version "1.6.21"
 	kotlin("plugin.jpa") version "1.6.21"
+	kotlin("kapt") version "1.7.10" // 1
 }
 
 group = "org.wait-for-me"
@@ -19,6 +20,9 @@ repositories {
 	mavenCentral()
 }
 
+val queryDSLVersion = "5.0.0"
+
+
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
@@ -27,6 +31,13 @@ dependencies {
 	runtimeOnly("com.h2database:h2")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	implementation("org.springdoc:springdoc-openapi-ui:1.6.11")
+
+	implementation("com.querydsl:querydsl-jpa:$queryDSLVersion") // 2
+	kapt("com.querydsl:querydsl-apt:$queryDSLVersion:jpa") // 1
+	implementation("javax.annotation:javax.annotation-api:1.3.2")
+	implementation("javax.persistence:javax.persistence-api:2.2")
+	annotationProcessor(group = "com.querydsl", name = "querydsl-apt", classifier = "jpa")
+	implementation("com.querydsl:querydsl-apt:$queryDSLVersion")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/org/waitforme/backend/api/BookmarkController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/BookmarkController.kt
@@ -1,0 +1,32 @@
+package org.waitforme.backend.api
+
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.waitforme.backend.model.response.bookmark.BookmarkResponse
+import org.waitforme.backend.service.BookmarkService
+
+
+@RestController
+@Tag(name = "북마크")
+@RequestMapping("/v1/bookmark")
+class BookmarkController(
+    private val bookmarkService: BookmarkService
+) {
+    @GetMapping("")
+    fun getBookmarkList(
+        @Parameter(name = "userId", description = "유저 ID", `in` = ParameterIn.QUERY)
+        userId: Int,
+        @Parameter(name = "page", description = "0페이지부터 시작", `in` = ParameterIn.QUERY)
+        page: Int? = 0,
+        @Parameter(name = "size", description = "1페이지 당 크기", `in` = ParameterIn.QUERY)
+        size: Int? = 10,
+    ): Page<BookmarkResponse> =
+        bookmarkService.findBookmarkList(userId, PageRequest.of(page ?: 0, size ?: 10))
+
+}

--- a/src/main/kotlin/org/waitforme/backend/api/BookmarkController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/BookmarkController.kt
@@ -5,9 +5,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.waitforme.backend.model.response.bookmark.BookmarkResponse
 import org.waitforme.backend.service.BookmarkService
 
@@ -28,5 +26,14 @@ class BookmarkController(
         size: Int? = 10,
     ): Page<BookmarkResponse> =
         bookmarkService.findBookmarkList(userId, PageRequest.of(page ?: 0, size ?: 10))
+
+    @PostMapping("/{shopId}")
+    fun updateBookmark(
+        @Parameter(name = "userId", description = "유저 ID", `in` = ParameterIn.QUERY)
+        userId: Int,
+        @Parameter(name = "shopId", description = "유저 ID", `in` = ParameterIn.PATH) @PathVariable
+        shopId: Int,
+    ): Boolean =
+        bookmarkService.updateBookmark(userId, shopId)
 
 }

--- a/src/main/kotlin/org/waitforme/backend/common/config/QuerydslConfig.kt
+++ b/src/main/kotlin/org/waitforme/backend/common/config/QuerydslConfig.kt
@@ -1,0 +1,19 @@
+package org.waitforme.backend.common.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Configuration
+class QuerydslConfig(
+    @PersistenceContext
+    private val entityManager: EntityManager
+) {
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/src/main/kotlin/org/waitforme/backend/entity/bookmark/Bookmark.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/bookmark/Bookmark.kt
@@ -1,0 +1,15 @@
+package org.waitforme.backend.entity.bookmark
+
+import org.waitforme.backend.common.BaseEntity
+import javax.persistence.*
+
+@Table(name = "bookmark")
+@Entity
+data class Bookmark(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Int = 0,
+    val userId: Int,
+    var shopId: Int,
+    var isShow: Boolean = true,
+) : BaseEntity()

--- a/src/main/kotlin/org/waitforme/backend/enums/EntryStatus.kt
+++ b/src/main/kotlin/org/waitforme/backend/enums/EntryStatus.kt
@@ -1,0 +1,5 @@
+package org.waitforme.backend.enums
+
+enum class EntryStatus {
+    WAIT, ENTRY, COMPLETED, CANCELED
+}

--- a/src/main/kotlin/org/waitforme/backend/enums/ShopStatus.kt
+++ b/src/main/kotlin/org/waitforme/backend/enums/ShopStatus.kt
@@ -1,0 +1,5 @@
+package org.waitforme.backend.enums
+
+enum class ShopStatus {
+    WAIT, PROGRESS, CLOSED
+}

--- a/src/main/kotlin/org/waitforme/backend/model/dto/bookmark/BookmarkResultDto.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/dto/bookmark/BookmarkResultDto.kt
@@ -1,0 +1,17 @@
+package org.waitforme.backend.model.dto.bookmark
+
+import org.waitforme.backend.enums.EntryStatus
+import org.waitforme.backend.enums.ShopStatus
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class BookmarkResultDto(
+    val shopId: Int,
+    val shopName: String,
+    val startedAt: LocalDate,
+    val endedAt: LocalDate,
+    val openedAt: LocalTime,
+    val closedAt: LocalTime,
+//    val status: EntryStatus,
+    val updatedAt: LocalDate,
+)

--- a/src/main/kotlin/org/waitforme/backend/model/response/bookmark/BookmarkResponse.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/response/bookmark/BookmarkResponse.kt
@@ -1,0 +1,28 @@
+package org.waitforme.backend.model.response.bookmark
+
+import org.waitforme.backend.enums.ShopStatus
+import org.waitforme.backend.model.dto.bookmark.BookmarkResultDto
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+data class BookmarkResponse(
+    val shopId: Int,
+    val shopName: String,
+    val shopStatus: ShopStatus,
+    val createdAt: LocalDate
+)
+
+fun BookmarkResultDto.toResponse(): BookmarkResponse {
+    val nowDateTime = LocalDateTime.now()
+    val shopOpenTime = LocalDateTime.of(startedAt, openedAt)
+    val shopCloseTime = LocalDateTime.of(endedAt, closedAt)
+    return BookmarkResponse(
+        shopId = shopId,
+        shopName = shopName,
+        shopStatus = if (shopOpenTime > nowDateTime) ShopStatus.WAIT
+            else if (shopOpenTime <= nowDateTime && nowDateTime < shopCloseTime) ShopStatus.PROGRESS
+            else ShopStatus.CLOSED,
+        createdAt = updatedAt
+    )
+}

--- a/src/main/kotlin/org/waitforme/backend/repository/bookmark/BookmarkCustomRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/bookmark/BookmarkCustomRepository.kt
@@ -1,0 +1,10 @@
+package org.waitforme.backend.repository.bookmark
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+import org.waitforme.backend.model.dto.bookmark.BookmarkResultDto
+
+interface BookmarkCustomRepository {
+    fun getBookmarkList(userId: Int, pageable: Pageable): Page<BookmarkResultDto>
+}

--- a/src/main/kotlin/org/waitforme/backend/repository/bookmark/BookmarkCustomRepositoryImpl.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/bookmark/BookmarkCustomRepositoryImpl.kt
@@ -1,0 +1,59 @@
+package org.waitforme.backend.repository.bookmark
+
+import com.querydsl.core.types.ExpressionUtils
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.JPAExpressions.select
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+import org.waitforme.backend.entity.bookmark.QBookmark
+import org.waitforme.backend.entity.shop.QShop
+import org.waitforme.backend.model.dto.bookmark.BookmarkResultDto
+
+@Repository
+class BookmarkCustomRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+): BookmarkCustomRepository {
+    private val bookmark = QBookmark.bookmark
+    private val shop = QShop.shop
+
+    override fun getBookmarkList(userId: Int, pageable: Pageable): Page<BookmarkResultDto> {
+        val content = queryFactory
+            .select(
+                Projections.fields(
+                    BookmarkResultDto::class.java,
+                    ExpressionUtils.`as`(shop.id, "shopId"),
+                    ExpressionUtils.`as`(shop.name, "shopName"),
+                    shop.startedAt,
+                    shop.endedAt,
+                    shop.openedAt,
+                    shop.closedAt,
+                    bookmark.updatedAt
+                )
+            )
+            .from(bookmark)
+            .innerJoin(shop).on(bookmark.shopId.eq(shop.id))
+            .where(
+                bookmark.userId.eq(userId),
+                bookmark.isShow.isTrue
+            )
+            .orderBy(bookmark.updatedAt.desc())
+            .limit(pageable.pageSize.toLong())
+            .offset(pageable.offset)
+            .fetch()
+
+        val count = queryFactory
+            .select(bookmark.count())
+            .from(bookmark)
+            .innerJoin(shop).on(bookmark.shopId.eq(shop.id))
+            .where(
+                bookmark.userId.eq(userId),
+                bookmark.isShow.isTrue
+            )
+            .fetchOne()
+
+        return PageImpl(content, pageable, count ?: 0)
+    }
+}

--- a/src/main/kotlin/org/waitforme/backend/repository/bookmark/BookmarkRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/bookmark/BookmarkRepository.kt
@@ -1,0 +1,11 @@
+package org.waitforme.backend.repository.bookmark
+
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+import org.waitforme.backend.entity.bookmark.Bookmark
+import org.waitforme.backend.model.dto.bookmark.BookmarkResultDto
+
+@Repository
+interface BookmarkRepository : CrudRepository<Bookmark, Int>, BookmarkCustomRepository {
+}

--- a/src/main/kotlin/org/waitforme/backend/repository/bookmark/BookmarkRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/bookmark/BookmarkRepository.kt
@@ -8,4 +8,6 @@ import org.waitforme.backend.model.dto.bookmark.BookmarkResultDto
 
 @Repository
 interface BookmarkRepository : CrudRepository<Bookmark, Int>, BookmarkCustomRepository {
+
+    fun findByUserIdAndShopId(userId: Int, shopId: Int): Bookmark?
 }

--- a/src/main/kotlin/org/waitforme/backend/service/BookmarkService.kt
+++ b/src/main/kotlin/org/waitforme/backend/service/BookmarkService.kt
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import org.waitforme.backend.entity.bookmark.Bookmark
 import org.waitforme.backend.model.response.bookmark.BookmarkResponse
 import org.waitforme.backend.model.response.bookmark.toResponse
 import org.waitforme.backend.repository.bookmark.BookmarkRepository
@@ -19,5 +20,19 @@ class BookmarkService(
         ).map {
             it.toResponse()
         }
+    }
+
+    fun updateBookmark(userId: Int, shopId: Int): Boolean {
+        val bookmark = bookmarkRepository.findByUserIdAndShopId(userId, shopId)
+        val result = bookmark?.let {
+            it.isShow = !it.isShow
+            it
+        } ?: Bookmark(
+            userId = userId,
+            shopId = shopId,
+            isShow = true
+        )
+
+        return bookmarkRepository.save(result).isShow
     }
 }

--- a/src/main/kotlin/org/waitforme/backend/service/BookmarkService.kt
+++ b/src/main/kotlin/org/waitforme/backend/service/BookmarkService.kt
@@ -1,0 +1,23 @@
+package org.waitforme.backend.service
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.waitforme.backend.model.response.bookmark.BookmarkResponse
+import org.waitforme.backend.model.response.bookmark.toResponse
+import org.waitforme.backend.repository.bookmark.BookmarkRepository
+
+@Service
+class BookmarkService(
+    private val bookmarkRepository: BookmarkRepository,
+) {
+    fun findBookmarkList(userId: Int, pageable: Pageable): Page<BookmarkResponse> {
+        return bookmarkRepository.getBookmarkList(
+            userId = userId,
+            pageable = pageable
+        ).map {
+            it.toResponse()
+        }
+    }
+}


### PR DESCRIPTION
### 📍 체크 리스트

- [ v ] 리뷰어를 설정했습니다.
- [ ] 블로킹 이슈가 있습니다. (`확인해야 할 부분`에 상세 설명 첨부)

### 🧱 구현 내용
- Querydsl을 사용하기 위한 설정 추가
- 북마크 리스트 조회 API 추가
- 북마크 추가/삭제 API 추가
  - userId와 shopId로 조회하여 있을 경우, 삭제 혹은 재등록 처리 // 없을 경우, 새로 추가하는 로직 구현

### 🚨 확인해야 할 부분
- 유저 엔티티가 추가된다면 userId를 받아오는 request를 로그인 유저의 JWT에서 가져오도록 수정해야 함