### PR TITLE
[FRONT] 유저 문자인증/회원가입/로그인 및 내정보 API 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,10 @@ dependencies {
 
     // validation
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    // sms api
+    implementation("net.nurigo:sdk:4.2.9")
+    // totp
+    implementation("dev.turingcomplete:kotlin-onetimepassword:2.4.0")
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,9 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-jackson:0.11.2")
 
     implementation("org.springframework.boot:spring-boot-starter-security")
+
+    // validation
+    implementation("org.springframework.boot:spring-boot-starter-validation")
 }
 
 tasks.withType<KotlinCompile> {

--- a/http/Admin.http
+++ b/http/Admin.http
@@ -1,0 +1,27 @@
+### 어드민 회원가입
+POST http://localhost:8080/v1/admin/sign-up
+Content-Type: application/json
+
+{
+  "email" : "test@email.com",
+  "password" : "12345678",
+  "name" : "어드민입니다만?"
+}
+
+### 어드민 로그인
+POST http://localhost:8080/v1/admin/sign-in
+Content-Type: application/json
+Authorization: Bearer {{auth_token}}
+
+{
+  "email" : "test@email.com",
+  "password" : "12345678"
+}
+
+//Saving a variable
+> {%
+client.global.set(
+"auth_token",
+"eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiIxIiwic3ViIjoi7Ja065Oc66-87J6F64uI64uk66eMPyIsImV4cCI6MTcwNjk4MDA1OSwiYXV0aG9yaXRpZXMiOiJBRE1JTiJ9.YRHSnyPiNUf8qvqP197XSOQMXgnl4CphmF_2fM1z30oygpWM434_p6LrA6m-JB5iOUYN0LxGmzUMngmmP9dXLQ"
+);
+%}

--- a/http/Auth.http
+++ b/http/Auth.http
@@ -1,0 +1,43 @@
+### 로컬 회원가입 인증 요청
+POST http://localhost:8080/v1/auth/local
+Content-Type: application/json
+
+{
+  "phoneNumber" : "01012345678"
+}
+
+### 로컬 회원가입 인증 확인
+PUT http://localhost:8080/v1/auth/local
+Content-Type: application/json
+
+{
+  "phoneNumber" : "01012345678",
+  "authText" : "722861"
+}
+
+### 로컬 회원가입
+POST http://localhost:8080/v1/auth/local/sign-up
+Content-Type: application/json
+
+{
+  "phoneNumber" : "01012345678",
+  "name" : "테스트입니다.",
+  "password" : "1234567"
+}
+
+### 로컬 로그인
+POST http://localhost:8080/v1/auth/local/sign-in
+Content-Type: application/json
+
+{
+  "phoneNumber" : "01012345678",
+  "password" : "1234567"
+}
+
+### 리프레시 토큰
+POST http://localhost:8080/v1/auth/local/refresh
+Content-Type: application/json
+
+{
+  "refreshToken" : "eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiIxIiwic3ViIjoi7YWM7Iqk7Yq47J6F64uI64ukLiIsImV4cCI6MTcwNjk3MzY5NSwiYXV0aG9yaXRpZXMiOiJVU0VSIn0.LULzWQvO33wOd7VCq4n3pkA-42HrxgxylA63ri37qzpivVAK_Sn6D6e5hka_Xp4pMS5aVAkxWH9p443_4QUVPg"
+}

--- a/http/Notice.http
+++ b/http/Notice.http
@@ -1,0 +1,17 @@
+### 어드민 회원가입
+POST http://localhost:8080/v1/notice
+Content-Type: application/json
+Authorization: Bearer {{auth_token}}
+
+{
+  "title" : "어드민의 공지입니다",
+  "contents" : "어드민은 공지가 하고 싶어~"
+}
+
+//Saving a variable
+> {%
+client.global.set(
+"auth_token",
+"eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiIxIiwic3ViIjoi7Ja065Oc66-87J6F64uI64uk66eMPyIsImV4cCI6MTcwNjk4NDAyMSwiYXV0aG9yaXRpZXMiOiJBRE1JTiJ9.xBC_9MnwCyrJ27JEVi_1pQ5Diz5eqD6XA1jw6AX30-UPuN66TEtu8A2ztAONZq-AGZh1vXueJz9rOFvbV2osHg"
+);
+%}

--- a/http/User.http
+++ b/http/User.http
@@ -1,0 +1,35 @@
+### 유저 정보 조회
+GET http://localhost:8080/v1/user/info
+Content-Type: application/json
+Authorization: Bearer {{auth_token}}
+
+//Saving a variable
+> {%
+client.global.set(
+"auth_token",
+"eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiIxIiwic3ViIjoi7YWM7Iqk7Yq47J6F64uI64ukLiIsImV4cCI6MTcwNjk3MzIwNywiYXV0aG9yaXRpZXMiOiJVU0VSIn0.jq_Rv5iBtXY968gnmONu6a43VC5pACrhfxhBkaC5WX0ep6rmhLvOmaTZUSfJEMdj8imW87EtWMMoxqXKKeqtVw"
+);
+%}
+
+### 유저 정보 수정
+PUT http://localhost:8080/v1/user/info
+Content-Type: application/json
+Authorization: Bearer {{auth_token}}
+
+//{
+//  "name" : "테스트라구요!",
+//  "birthedAt" : "2023-01-18T11:22:33",
+//  "gender" : "FEMALE"
+//}
+
+{
+  "name" : "최종 찐 테스트라구요!"
+}
+
+//Saving a variable
+> {%
+client.global.set(
+"auth_token",
+"eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiIxIiwic3ViIjoi7YWM7Iqk7Yq47J6F64uI64ukLiIsImV4cCI6MTcwNjk3NjE2OCwiYXV0aG9yaXRpZXMiOiJVU0VSIn0.NwTfnJ-Tv-e9X7RSsZt3X8S5Z5R6kbmeFsp2klFrbZTHiQL6GHhsg6gtNx6ai6WX1kzTxceal1F-QQRbi-eJZg"
+);
+%}

--- a/src/main/kotlin/org/waitforme/backend/api/AdminController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/AdminController.kt
@@ -25,10 +25,10 @@ class AdminController(
     ): AdminAuthResponse = adminService.signUp(request)
 
     @PreAuthorize("permitAll()")
-    @PostMapping("/login")
-    fun loginAdmin(
+    @PostMapping("/sign-in")
+    fun signInAdmin(
         @RequestBody request: AdminAuthRequest,
-    ): AdminAuthResponse = adminService.login(request)
+    ): AdminAuthResponse = adminService.signIn(request)
 
     // TODO : 관리자 승인 및 권한 설정해주는 API 만들기
 }

--- a/src/main/kotlin/org/waitforme/backend/api/AuthController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/AuthController.kt
@@ -3,11 +3,14 @@ package org.waitforme.backend.api
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
+import org.waitforme.backend.model.dto.JwtDto
 import org.waitforme.backend.model.request.auth.LocalAuthRequest
+import org.waitforme.backend.model.request.auth.LocalRefreshTokenRequest
 import org.waitforme.backend.model.request.auth.LocalSignInRequest
 import org.waitforme.backend.model.request.auth.LocalSignUpRequest
 import org.waitforme.backend.model.response.auth.AuthResponse
 import org.waitforme.backend.service.AuthService
+import javax.validation.Valid
 
 @RestController
 @Tag(name = "회원가입/로그인 API")
@@ -18,7 +21,7 @@ class AuthController(
     @Operation(summary = "로컬 회원가입 시 인증 요청", description = "로컬 회원가입 시 인증 요청")
     @PostMapping("/local")
     fun requestAuthLocal(
-        @RequestBody request: LocalAuthRequest,
+        @Valid @RequestBody request: LocalAuthRequest,
     ): Boolean {
         return authService.requestAuthLocal(request = request)
     }
@@ -26,7 +29,7 @@ class AuthController(
     @Operation(summary = "로컬 회원가입 시 인증 확인", description = "로컬 회원가입 시 인증 확인")
     @PutMapping("/local")
     fun verifyAuthLocal(
-        @RequestBody request: LocalAuthRequest,
+        @Valid @RequestBody request: LocalAuthRequest,
     ): Boolean {
         return authService.verifyAuthLocal(request = request)
     }
@@ -34,7 +37,7 @@ class AuthController(
     @Operation(summary = "로컬 회원가입", description = "로컬 회원가입을 합니다.")
     @PostMapping("/local/sign-up")
     fun signUpLocal(
-        @RequestBody request: LocalSignUpRequest,
+        @Valid @RequestBody request: LocalSignUpRequest,
     ): AuthResponse {
         return authService.signUpLocal(request = request)
     }
@@ -42,8 +45,14 @@ class AuthController(
     @Operation(summary = "로컬 로그인", description = "로컬 로그인을 합니다.")
     @PostMapping("/local/sign-in")
     fun signInLocal(
-        @RequestBody request: LocalSignInRequest,
+        @Valid @RequestBody request: LocalSignInRequest,
     ): AuthResponse {
         return authService.signInLocal(request = request)
+    }
+
+    @Operation(summary = "리프레시 토큰으로 액세스 토큰 재발급", description = "리프레시 토큰으로 액세스 토큰을 재발급합니다.")
+    @PostMapping("/local/refresh")
+    fun refresh(@RequestBody request: LocalRefreshTokenRequest): JwtDto {
+        return authService.refresh(request.refreshToken)
     }
 }

--- a/src/main/kotlin/org/waitforme/backend/api/AuthController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/AuthController.kt
@@ -2,11 +2,10 @@ package org.waitforme.backend.api
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.waitforme.backend.model.request.auth.LocalAuthRequest
+import org.waitforme.backend.model.request.auth.LocalSignInRequest
+import org.waitforme.backend.model.request.auth.LocalSignUpRequest
 import org.waitforme.backend.model.response.auth.AuthResponse
 import org.waitforme.backend.service.AuthService
 
@@ -16,19 +15,34 @@ import org.waitforme.backend.service.AuthService
 class AuthController(
     private val authService: AuthService,
 ) {
+    @Operation(summary = "로컬 회원가입 시 인증 요청", description = "로컬 회원가입 시 인증 요청")
+    @PostMapping("/local")
+    fun requestAuthLocal(
+        @RequestBody request: LocalAuthRequest,
+    ): Boolean {
+        return authService.requestAuthLocal(request = request)
+    }
+
+    @Operation(summary = "로컬 회원가입 시 인증 확인", description = "로컬 회원가입 시 인증 확인")
+    @PutMapping("/local")
+    fun verifyAuthLocal(
+        @RequestBody request: LocalAuthRequest,
+    ): Boolean {
+        return authService.verifyAuthLocal(request = request)
+    }
 
     @Operation(summary = "로컬 회원가입", description = "로컬 회원가입을 합니다.")
-    @PostMapping("/sign-up/local")
+    @PostMapping("/local/sign-up")
     fun signUpLocal(
-        @RequestBody request: LocalAuthRequest,
+        @RequestBody request: LocalSignUpRequest,
     ): AuthResponse {
         return authService.signUpLocal(request = request)
     }
 
     @Operation(summary = "로컬 로그인", description = "로컬 로그인을 합니다.")
-    @PostMapping("/sign-in/local")
+    @PostMapping("/local/sign-in")
     fun signInLocal(
-        @RequestBody request: LocalAuthRequest,
+        @RequestBody request: LocalSignInRequest,
     ): AuthResponse {
         return authService.signInLocal(request = request)
     }

--- a/src/main/kotlin/org/waitforme/backend/api/AuthController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/AuthController.kt
@@ -1,0 +1,35 @@
+package org.waitforme.backend.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.waitforme.backend.model.request.auth.LocalAuthRequest
+import org.waitforme.backend.model.response.auth.AuthResponse
+import org.waitforme.backend.service.AuthService
+
+@RestController
+@Tag(name = "회원가입/로그인 API")
+@RequestMapping("/v1/auth")
+class AuthController(
+    private val authService: AuthService,
+) {
+
+    @Operation(summary = "로컬 회원가입", description = "로컬 회원가입을 합니다.")
+    @PostMapping("/sign-up/local")
+    fun signUpLocal(
+        @RequestBody request: LocalAuthRequest,
+    ): AuthResponse {
+        return authService.signUpLocal(request = request)
+    }
+
+    @Operation(summary = "로컬 로그인", description = "로컬 로그인을 합니다.")
+    @PostMapping("/sign-in/local")
+    fun signInLocal(
+        @RequestBody request: LocalAuthRequest,
+    ): AuthResponse {
+        return authService.signInLocal(request = request)
+    }
+}

--- a/src/main/kotlin/org/waitforme/backend/api/NoticeController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/NoticeController.kt
@@ -12,6 +12,7 @@ import org.waitforme.backend.model.request.notice.NoticeRequest
 import org.waitforme.backend.model.response.notice.NoticeListResponse
 import org.waitforme.backend.model.response.notice.NoticeResponse
 import org.waitforme.backend.service.NoticeService
+import javax.annotation.security.RolesAllowed
 
 @RestController
 @Tag(name = "공지 API")
@@ -37,7 +38,7 @@ class NoticeController(
     ): NoticeResponse =
         noticeService.findNotice(noticeId = id)
 
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')") // defaultPrefix 'ROLE'이 붙어야 해서 hasAuthority 대신 hasRole
     @PostMapping("")
     fun createNotice(
         @Parameter(hidden = true) @AuthenticationPrincipal loginAdmin: LoginAdmin,
@@ -45,7 +46,7 @@ class NoticeController(
     ): Int =
         noticeService.saveNotice(request = noticeRequest, loginAdmin = loginAdmin)
 
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/{id}")
     fun modifyNotice(
         @Parameter(hidden = true) @AuthenticationPrincipal loginAdmin: LoginAdmin,
@@ -54,7 +55,7 @@ class NoticeController(
     ): Int =
         noticeService.saveNotice(noticeId = id, request = noticeRequest, loginAdmin = loginAdmin)
 
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{id}")
     fun deleteNotice(
         @Parameter(hidden = true) @AuthenticationPrincipal loginAdmin: LoginAdmin,

--- a/src/main/kotlin/org/waitforme/backend/api/NoticeController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/NoticeController.kt
@@ -42,7 +42,7 @@ class NoticeController(
     fun createNotice(
         @Parameter(hidden = true) @AuthenticationPrincipal loginAdmin: LoginAdmin,
         @RequestBody noticeRequest: NoticeRequest,
-    ): NoticeResponse =
+    ): Int =
         noticeService.saveNotice(request = noticeRequest, loginAdmin = loginAdmin)
 
     @PreAuthorize("hasAuthority('ADMIN')")
@@ -51,7 +51,7 @@ class NoticeController(
         @Parameter(hidden = true) @AuthenticationPrincipal loginAdmin: LoginAdmin,
         @Parameter(name = "id", description = "공지 ID", `in` = ParameterIn.PATH) @PathVariable id: Int,
         @RequestBody noticeRequest: NoticeRequest,
-    ): NoticeResponse =
+    ): Int =
         noticeService.saveNotice(noticeId = id, request = noticeRequest, loginAdmin = loginAdmin)
 
     @PreAuthorize("hasAuthority('ADMIN')")

--- a/src/main/kotlin/org/waitforme/backend/api/NoticeController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/NoticeController.kt
@@ -11,8 +11,8 @@ import org.waitforme.backend.model.LoginAdmin
 import org.waitforme.backend.model.request.notice.NoticeRequest
 import org.waitforme.backend.model.response.notice.NoticeListResponse
 import org.waitforme.backend.model.response.notice.NoticeResponse
+import org.waitforme.backend.model.response.notice.NoticeSaveResponse
 import org.waitforme.backend.service.NoticeService
-import javax.annotation.security.RolesAllowed
 
 @RestController
 @Tag(name = "공지 API")
@@ -43,7 +43,7 @@ class NoticeController(
     fun createNotice(
         @Parameter(hidden = true) @AuthenticationPrincipal loginAdmin: LoginAdmin,
         @RequestBody noticeRequest: NoticeRequest,
-    ): Int =
+    ): NoticeSaveResponse =
         noticeService.saveNotice(request = noticeRequest, loginAdmin = loginAdmin)
 
     @PreAuthorize("hasRole('ADMIN')")
@@ -52,7 +52,7 @@ class NoticeController(
         @Parameter(hidden = true) @AuthenticationPrincipal loginAdmin: LoginAdmin,
         @Parameter(name = "id", description = "공지 ID", `in` = ParameterIn.PATH) @PathVariable id: Int,
         @RequestBody noticeRequest: NoticeRequest,
-    ): Int =
+    ): NoticeSaveResponse =
         noticeService.saveNotice(noticeId = id, request = noticeRequest, loginAdmin = loginAdmin)
 
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/kotlin/org/waitforme/backend/api/UserController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/UserController.kt
@@ -1,0 +1,33 @@
+package org.waitforme.backend.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import org.waitforme.backend.model.LoginUser
+import org.waitforme.backend.model.request.user.UserInfoRequest
+import org.waitforme.backend.model.response.user.UserInfoResponse
+import org.waitforme.backend.service.UserService
+
+@RestController
+@Tag(name = "유저 관련 API")
+@RequestMapping("/v1/user")
+class UserController(
+    private val userService: UserService,
+) {
+
+    @Operation(summary = "회원 정보 조회", description = "회원 정보를 조회합니다.")
+    @GetMapping("/info")
+    fun getUserInfo(
+        @Parameter(hidden = true) @AuthenticationPrincipal loginUser: LoginUser,
+    ): UserInfoResponse = userService.getUserInfo(userId = loginUser.id)
+
+    @Operation(summary = "회원 정보 수정", description = "회원 정보를 수정합니다.")
+    @PutMapping("/info", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun saveUserInfo(
+        @Parameter(hidden = true) @AuthenticationPrincipal loginUser: LoginUser,
+        @Parameter userInfoRequest: UserInfoRequest,
+    ): UserInfoResponse = userService.saveUserInfo(userId = loginUser.id, request = userInfoRequest)
+}

--- a/src/main/kotlin/org/waitforme/backend/api/UserController.kt
+++ b/src/main/kotlin/org/waitforme/backend/api/UserController.kt
@@ -3,7 +3,6 @@ package org.waitforme.backend.api
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.http.MediaType
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import org.waitforme.backend.model.LoginUser
@@ -25,9 +24,12 @@ class UserController(
     ): UserInfoResponse = userService.getUserInfo(userId = loginUser.id)
 
     @Operation(summary = "회원 정보 수정", description = "회원 정보를 수정합니다.")
-    @PutMapping("/info", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @PutMapping(
+        "/info",
+//        , consumes = [MediaType.MULTIPART_FORM_DATA_VALUE]
+    )
     fun saveUserInfo(
         @Parameter(hidden = true) @AuthenticationPrincipal loginUser: LoginUser,
-        @Parameter userInfoRequest: UserInfoRequest,
+        @RequestBody userInfoRequest: UserInfoRequest,
     ): UserInfoResponse = userService.saveUserInfo(userId = loginUser.id, request = userInfoRequest)
 }

--- a/src/main/kotlin/org/waitforme/backend/common/SmsUtil.kt
+++ b/src/main/kotlin/org/waitforme/backend/common/SmsUtil.kt
@@ -1,0 +1,39 @@
+package org.waitforme.backend.common
+
+import net.nurigo.sdk.NurigoApp.initialize
+import net.nurigo.sdk.message.exception.NurigoMessageNotReceivedException
+import net.nurigo.sdk.message.model.Message
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "sms")
+class SmsUtil {
+
+    lateinit var fromNumber: String
+    lateinit var apiKey: String
+    lateinit var apiSecretKey: String
+
+    fun sendSms(toPhoneNumber: String, authText: String): Boolean {
+        val messageService = initialize(apiKey, apiSecretKey, "https://api.solapi.com")
+        val message = Message()
+        message.apply {
+            from = fromNumber // 계정에서 등록한 발신번호 입력
+            to = toPhoneNumber // 수신번호 입력
+            text = "[WAIT-FOR-ME] 인증번호를 입력해주세요. $authText" // SMS는 한글 45자, 영자 90자까지 입력할 수 있습니다.
+        }
+
+        return try {
+            // send 메소드로 ArrayList<Message> 객체를 넣어도 동작합니다!
+            messageService.send(message)
+            true
+        } catch (exception: NurigoMessageNotReceivedException) {
+            println(exception.failedMessageList)
+            println(exception.message)
+            false
+        } catch (exception: Exception) {
+            println(exception.message)
+            false
+        }
+    }
+}

--- a/src/main/kotlin/org/waitforme/backend/common/TotpUtil.kt
+++ b/src/main/kotlin/org/waitforme/backend/common/TotpUtil.kt
@@ -1,0 +1,46 @@
+package org.waitforme.backend.common
+
+import dev.turingcomplete.kotlinonetimepassword.HmacAlgorithm
+import dev.turingcomplete.kotlinonetimepassword.TimeBasedOneTimePasswordConfig
+import dev.turingcomplete.kotlinonetimepassword.TimeBasedOneTimePasswordGenerator
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+import java.util.Date
+import java.util.concurrent.TimeUnit
+import javax.annotation.PostConstruct
+
+@Component
+@ConfigurationProperties(prefix = "totp")
+class TotpUtil() {
+    lateinit var secret: String
+    lateinit var validTime: String
+
+    lateinit var config: TimeBasedOneTimePasswordConfig
+    lateinit var timeBasedOneTimePasswordGenerator: TimeBasedOneTimePasswordGenerator
+
+    @PostConstruct
+    fun init() {
+        config = TimeBasedOneTimePasswordConfig(
+            codeDigits = 6,
+            hmacAlgorithm = HmacAlgorithm.SHA1,
+            timeStep = 10000,
+            timeStepUnit = TimeUnit.MILLISECONDS,
+        )
+
+        timeBasedOneTimePasswordGenerator = TimeBasedOneTimePasswordGenerator(secret.toByteArray(), config)
+    }
+
+    fun generateTotp(date: Date): String {
+        return timeBasedOneTimePasswordGenerator.generate(date = date)
+    }
+
+    fun isValidTotp(code: String, date: Date): Boolean {
+        return if (checkValidTime(code, date)) timeBasedOneTimePasswordGenerator.isValid(code, date) else false
+    }
+
+    fun checkValidTime(code: String, date: Date): Boolean {
+        val now = System.currentTimeMillis()
+        val startEpochMillis = date.toInstant().epochSecond * 1000
+        return (now - startEpochMillis) < validTime.toLong()
+    }
+}

--- a/src/main/kotlin/org/waitforme/backend/config/security/JwtTokenProvider.kt
+++ b/src/main/kotlin/org/waitforme/backend/config/security/JwtTokenProvider.kt
@@ -63,7 +63,7 @@ class JwtTokenProvider(
             .compact()
     }
 
-    fun createJwt(id: Int, email: String, name: String, role: UserRole): JwtDto {
+    fun createJwt(id: Int, account: String, name: String, role: UserRole): JwtDto {
         val now = System.currentTimeMillis()
         val nowLocalDateTime = toLocalDateTime(Instant.ofEpochMilli(now))
 
@@ -85,7 +85,7 @@ class JwtTokenProvider(
                 expiredAt = toLocalDateTime(refreshTokenExpireTime.toInstant()),
 
             ),
-            email = email,
+            account = account,
             name = name,
         )
     }

--- a/src/main/kotlin/org/waitforme/backend/config/security/JwtTokenProvider.kt
+++ b/src/main/kotlin/org/waitforme/backend/config/security/JwtTokenProvider.kt
@@ -27,6 +27,7 @@ import java.time.ZoneId
 import java.util.*
 import javax.annotation.PostConstruct
 import javax.crypto.SecretKey
+import javax.security.auth.message.AuthException
 import javax.servlet.http.HttpServletRequest
 
 @Component
@@ -154,6 +155,14 @@ class JwtTokenProvider(
         }.onFailure {
             logger.warn("accessToken 만료 또는 잘못된 형식입니다.")
         }.getOrElse { false }
+    }
+
+    fun validateRefreshToken(token: String) {
+        runCatching {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token)
+        }.onFailure {
+            throw AuthException("refreshToken 만료 또는 잘못된 형식으로 로그인이 필요합니다.")
+        }
     }
 
     private fun toLocalDateTime(instant: Instant) = LocalDateTime.ofInstant(instant, ZoneId.systemDefault())

--- a/src/main/kotlin/org/waitforme/backend/config/security/JwtTokenProvider.kt
+++ b/src/main/kotlin/org/waitforme/backend/config/security/JwtTokenProvider.kt
@@ -118,7 +118,7 @@ class JwtTokenProvider(
         // ROLE
         val id = claims.id.toInt()
         val role = claims[AUTHORITIES_KEY].toString()
-        val authorities = SimpleGrantedAuthority(role)
+        val authorities = UserRole.valueOf(role).authorities.map { SimpleGrantedAuthority(it) }
 
         val userDetails =
             when (role) {
@@ -147,7 +147,7 @@ class JwtTokenProvider(
                 }
             }
 
-        return UsernamePasswordAuthenticationToken(userDetails, token, listOf(authorities))
+        return UsernamePasswordAuthenticationToken(userDetails, token, authorities)
     }
 
     // Request Header에서 토큰 정보를 꺼내오기 위한 메소드

--- a/src/main/kotlin/org/waitforme/backend/config/security/JwtTokenProvider.kt
+++ b/src/main/kotlin/org/waitforme/backend/config/security/JwtTokenProvider.kt
@@ -18,7 +18,9 @@ import org.waitforme.backend.enums.UserRole
 import org.waitforme.backend.model.LoginAdmin
 import org.waitforme.backend.model.dto.JwtDto
 import org.waitforme.backend.model.dto.TokenDto
+import org.waitforme.backend.model.toLoginUser
 import org.waitforme.backend.repository.admin.AdminRepository
+import org.waitforme.backend.repository.user.UserRepository
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -31,6 +33,7 @@ import javax.servlet.http.HttpServletRequest
 @ConfigurationProperties(prefix = "jwt")
 class JwtTokenProvider(
     private val adminRepository: AdminRepository,
+    private val userRepository: UserRepository,
 ) {
 
     lateinit var tokenSecretKey: String
@@ -112,16 +115,16 @@ class JwtTokenProvider(
                 }
 
                 UserRole.USER.name -> {
-                    // TODO
-                    adminRepository.findByIdOrNull(id)?.let { admin ->
-                        LoginAdmin(admin)
+                    userRepository.findByIdOrNull(id)?.let { user ->
+                        // TODO : 확인 필요 - isOwner 체크 필요?
+                        user.toLoginUser()
                     } ?: throw UsernameNotFoundException(id.toString())
                 }
 
                 UserRole.OWNER.name -> {
-                    // TODO
-                    adminRepository.findByIdOrNull(id)?.let { admin ->
-                        LoginAdmin(admin)
+                    userRepository.findByIdOrNull(id)?.let { user ->
+                        // TODO : 확인 필요 - isOwner 체크 필요?
+                        user.toLoginUser()
                     } ?: throw UsernameNotFoundException(id.toString())
                 }
 

--- a/src/main/kotlin/org/waitforme/backend/config/security/JwtTokenProvider.kt
+++ b/src/main/kotlin/org/waitforme/backend/config/security/JwtTokenProvider.kt
@@ -131,6 +131,7 @@ class JwtTokenProvider(
                 UserRole.USER.name -> {
                     userRepository.findByIdOrNull(id)?.let { user ->
                         // TODO : 확인 필요 - isOwner 체크 필요?
+                        // findByIdAndIsOwner(id, true) 으로 체크
                         user.toLoginUser()
                     } ?: throw UsernameNotFoundException(id.toString())
                 }
@@ -138,6 +139,7 @@ class JwtTokenProvider(
                 UserRole.OWNER.name -> {
                     userRepository.findByIdOrNull(id)?.let { user ->
                         // TODO : 확인 필요 - isOwner 체크 필요?
+                        // findByIdAndIsOwner(id, true) 으로 체크
                         user.toLoginUser()
                     } ?: throw UsernameNotFoundException(id.toString())
                 }

--- a/src/main/kotlin/org/waitforme/backend/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/org/waitforme/backend/config/security/SecurityConfig.kt
@@ -3,10 +3,6 @@ package org.waitforme.backend.config.security
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.access.expression.SecurityExpressionHandler
-import org.springframework.security.access.hierarchicalroles.RoleHierarchy
-import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl
-import org.springframework.security.access.hierarchicalroles.RoleHierarchyUtils
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -15,8 +11,6 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.DefaultSecurityFilterChain
-import org.springframework.security.web.FilterInvocation
-import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 
@@ -36,6 +30,7 @@ class SecurityConfig(
             "/v1/admin/sign-up",
             "/v1/admin/login",
             "/v1/auth/**",
+            "/v1/notice/**",
         )
 
     @Bean

--- a/src/main/kotlin/org/waitforme/backend/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/org/waitforme/backend/config/security/SecurityConfig.kt
@@ -3,6 +3,10 @@ package org.waitforme.backend.config.security
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.access.expression.SecurityExpressionHandler
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyUtils
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -11,6 +15,8 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.DefaultSecurityFilterChain
+import org.springframework.security.web.FilterInvocation
+import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 
@@ -29,7 +35,7 @@ class SecurityConfig(
             "/swagger-ui/**",
             "/v1/admin/sign-up",
             "/v1/admin/login",
-            "/v1/auth/**"
+            "/v1/auth/**",
         )
 
     @Bean

--- a/src/main/kotlin/org/waitforme/backend/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/org/waitforme/backend/config/security/SecurityConfig.kt
@@ -29,6 +29,7 @@ class SecurityConfig(
             "/swagger-ui/**",
             "/v1/admin/sign-up",
             "/v1/admin/login",
+            "/v1/auth/**"
         )
 
     @Bean

--- a/src/main/kotlin/org/waitforme/backend/entity/admin/Admin.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/admin/Admin.kt
@@ -24,7 +24,7 @@ data class Admin(
 ) : BaseEntity(),
     UserDetails {
     override fun getAuthorities(): Collection<GrantedAuthority> {
-        return listOf<GrantedAuthority>(SimpleGrantedAuthority(UserRole.ADMIN.name))
+        return UserRole.ADMIN.authorities.map { SimpleGrantedAuthority(it) }
     }
 
     override fun getPassword(): String {

--- a/src/main/kotlin/org/waitforme/backend/entity/admin/AdminHistory.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/admin/AdminHistory.kt
@@ -1,0 +1,19 @@
+package org.waitforme.backend.entity.admin
+
+import org.waitforme.backend.common.BaseEntity
+import org.waitforme.backend.enums.AdminAction
+import org.waitforme.backend.enums.AdminMenuCode
+import javax.persistence.*
+
+@Table(name = "admin_history")
+@Entity
+data class AdminHistory(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Int = 0,
+    val adminId: Int,
+    val menuCode: AdminMenuCode,
+    val menuId: Int,
+    val action: AdminAction,
+    val memo: String? = null,
+) : BaseEntity()

--- a/src/main/kotlin/org/waitforme/backend/entity/user/User.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/user/User.kt
@@ -4,6 +4,7 @@ import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 import org.waitforme.backend.common.BaseEntity
+import org.waitforme.backend.enums.GenderType
 import org.waitforme.backend.enums.Provider
 import org.waitforme.backend.enums.UserRole
 import java.time.LocalDateTime
@@ -20,8 +21,11 @@ data class User(
     val phoneNumber: String,
     val snsId: String? = null,
     val email: String? = null,
-    val name: String,
+    var name: String,
     private val password: String? = null,
+    var birthedAt: LocalDateTime? = null,
+    var gender: GenderType? = null,
+    val profileImage: String? = null,
     val isOwner: Boolean = false,
     val isAuth: Boolean = false, // 인증 여부, sns로 등록 시 자동 인증, local은 회원 가입 시 인증 절차 필요
     val isAdult: Boolean = false,

--- a/src/main/kotlin/org/waitforme/backend/entity/user/User.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/user/User.kt
@@ -1,0 +1,68 @@
+package org.waitforme.backend.entity.user
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+import org.waitforme.backend.common.BaseEntity
+import org.waitforme.backend.enums.Provider
+import org.waitforme.backend.enums.UserRole
+import java.time.LocalDateTime
+import javax.persistence.*
+import javax.security.auth.message.AuthException
+
+@Table(name = "user")
+@Entity
+data class User(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Int = 0,
+    val provider: Provider,
+    val phoneNumber: String,
+    val snsId: String? = null,
+    val email: String? = null,
+    val name: String,
+    private val password: String? = null,
+    val isOwner: Boolean = false,
+    val isAuth: Boolean? = false, // 인증 여부, sns로 등록 시 자동 인증, local은 회원 가입 시 인증 절차 필요
+    val isAdult: Boolean = false,
+    val isDeleted: Boolean = false,
+    var deletedAt: LocalDateTime? = null,
+) : BaseEntity(), UserDetails {
+    override fun getAuthorities(): Collection<GrantedAuthority> {
+        return if (isOwner) {
+            listOf<GrantedAuthority>(SimpleGrantedAuthority(UserRole.OWNER.name))
+        } else {
+            listOf<GrantedAuthority>(SimpleGrantedAuthority(UserRole.USER.name))
+        }
+    }
+
+    override fun getPassword(): String? {
+        return password // TODO: null이어도 되나..? 확인 필요
+    }
+
+    override fun getUsername(): String {
+        return name
+    }
+
+    override fun isEnabled(): Boolean {
+        return !isDeleted
+    }
+
+    override fun isAccountNonExpired(): Boolean {
+        return true
+    }
+
+    override fun isAccountNonLocked(): Boolean {
+        return true
+    }
+
+    override fun isCredentialsNonExpired(): Boolean {
+        return true
+    }
+
+    fun checkDeletedUser() {
+        if (isDeleted && deletedAt != null) {
+            throw AuthException("탈퇴 처리가 된 유저입니다.")
+        }
+    }
+}

--- a/src/main/kotlin/org/waitforme/backend/entity/user/User.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/user/User.kt
@@ -39,9 +39,9 @@ data class User(
 ) : BaseEntity(), UserDetails {
     override fun getAuthorities(): Collection<GrantedAuthority> {
         return if (isOwner) {
-            listOf<GrantedAuthority>(SimpleGrantedAuthority(UserRole.OWNER.name))
+            UserRole.OWNER.authorities.map { SimpleGrantedAuthority(it) }
         } else {
-            listOf<GrantedAuthority>(SimpleGrantedAuthority(UserRole.USER.name))
+            UserRole.USER.authorities.map { SimpleGrantedAuthority(it) }
         }
     }
 

--- a/src/main/kotlin/org/waitforme/backend/entity/user/User.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/user/User.kt
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
 import javax.persistence.*
 import javax.security.auth.message.AuthException
 
-@Table(name = "user")
+@Table(name = "`user`")
 @Entity
 data class User(
     @Id
@@ -23,7 +23,7 @@ data class User(
     val name: String,
     private val password: String? = null,
     val isOwner: Boolean = false,
-    val isAuth: Boolean? = false, // 인증 여부, sns로 등록 시 자동 인증, local은 회원 가입 시 인증 절차 필요
+    val isAuth: Boolean = false, // 인증 여부, sns로 등록 시 자동 인증, local은 회원 가입 시 인증 절차 필요
     val isAdult: Boolean = false,
     val isDeleted: Boolean = false,
     var deletedAt: LocalDateTime? = null,
@@ -61,8 +61,14 @@ data class User(
     }
 
     fun checkDeletedUser() {
-        if (isDeleted && deletedAt != null) {
-            throw AuthException("탈퇴 처리가 된 유저입니다.")
+        if (isDeleted || deletedAt != null) {
+            throw AuthException("탈퇴 처리된 계정입니다.")
+        }
+    }
+
+    fun checkAuthUser() {
+        if (!isAuth) {
+            throw AuthException("인증이 확인되지 않은 계정입니다.")
         }
     }
 }

--- a/src/main/kotlin/org/waitforme/backend/entity/user/User.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/user/User.kt
@@ -7,6 +7,7 @@ import org.waitforme.backend.common.BaseEntity
 import org.waitforme.backend.enums.GenderType
 import org.waitforme.backend.enums.Provider
 import org.waitforme.backend.enums.UserRole
+import java.time.LocalDate
 import java.time.LocalDateTime
 import javax.persistence.*
 import javax.security.auth.message.AuthException
@@ -25,16 +26,16 @@ data class User(
     val provider: Provider,
     val phoneNumber: String,
     val snsId: String? = null,
-    val email: String? = null,
+    var email: String? = null,
     var name: String,
-    private val password: String? = null,
-    var birthedAt: LocalDateTime? = null,
+    private var password: String? = null,
+    var birthedAt: LocalDate? = null,
     var gender: GenderType? = null,
     val profileImage: String? = null,
-    val isOwner: Boolean = false,
-    val isAuth: Boolean = false, // 인증 여부, sns로 등록 시 자동 인증, local은 회원 가입 시 인증 절차 필요
-    val isAdult: Boolean = false,
-    val isDeleted: Boolean = false,
+    var isOwner: Boolean = false,
+    var isAuth: Boolean = false, // 인증 여부, sns로 등록 시 자동 인증, local은 회원 가입 시 인증 절차 필요
+    var isAdult: Boolean = false,
+    var isDeleted: Boolean = false,
     var deletedAt: LocalDateTime? = null,
 ) : BaseEntity(), UserDetails {
     override fun getAuthorities(): Collection<GrantedAuthority> {

--- a/src/main/kotlin/org/waitforme/backend/entity/user/User.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/user/User.kt
@@ -11,8 +11,13 @@ import java.time.LocalDateTime
 import javax.persistence.*
 import javax.security.auth.message.AuthException
 
-@Table(name = "`user`")
 @Entity
+@Table(
+    name = "`user`",
+    indexes = [
+        Index(name = "idx_provider_phone_number", columnList = "provider, phoneNumber", unique = true), // index (unique = false (default))
+    ]
+)
 data class User(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/org/waitforme/backend/entity/user/UserAuth.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/user/UserAuth.kt
@@ -11,6 +11,6 @@ data class UserAuth(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Int = 0,
     val phoneNumber: String, // TODO : unique index 걸기
-    var requestedAt: LocalDateTime,
+    var requestedAt: LocalDateTime, // TODO : Long으로 바꾸기
     var authenticatedAt: LocalDateTime? = null,
 ) : BaseEntity()

--- a/src/main/kotlin/org/waitforme/backend/entity/user/UserAuth.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/user/UserAuth.kt
@@ -1,0 +1,17 @@
+package org.waitforme.backend.entity.user
+
+import org.waitforme.backend.common.BaseEntity
+import java.time.LocalDateTime
+import javax.persistence.*
+
+@Table(name = "user_auth")
+@Entity
+data class UserAuth(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Int = 0,
+    val phoneNumber: String, // TODO : unique index 걸기
+    var authText: String,
+    var requestedAt: LocalDateTime = LocalDateTime.now(),
+    var authenticatedAt: LocalDateTime? = null,
+) : BaseEntity()

--- a/src/main/kotlin/org/waitforme/backend/entity/user/UserAuth.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/user/UserAuth.kt
@@ -4,14 +4,13 @@ import org.waitforme.backend.common.BaseEntity
 import java.time.LocalDateTime
 import javax.persistence.*
 
-@Table(name = "user_auth")
+@Table(name = "user_auth") // TODO: userAuthLog?
 @Entity
 data class UserAuth(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Int = 0,
     val phoneNumber: String, // TODO : unique index 걸기
-    var authText: String,
-    var requestedAt: LocalDateTime = LocalDateTime.now(),
+    var requestedAt: LocalDateTime,
     var authenticatedAt: LocalDateTime? = null,
 ) : BaseEntity()

--- a/src/main/kotlin/org/waitforme/backend/entity/user/UserRefreshToken.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/user/UserRefreshToken.kt
@@ -9,7 +9,7 @@ import javax.persistence.*
 data class UserRefreshToken(
     @Id
     @GeneratedValue
-    val id: Long? = null,
+    val id: Int? = null,
     val userId: Int,
     @Column(columnDefinition = "TEXT")
     var refreshToken: String,

--- a/src/main/kotlin/org/waitforme/backend/entity/user/UserRefreshToken.kt
+++ b/src/main/kotlin/org/waitforme/backend/entity/user/UserRefreshToken.kt
@@ -1,0 +1,21 @@
+package org.waitforme.backend.entity.user
+
+import org.waitforme.backend.common.BaseEntity
+import java.time.LocalDateTime
+import javax.persistence.*
+
+@Entity
+@Table(name = "user_refresh_token")
+data class UserRefreshToken(
+    @Id
+    @GeneratedValue
+    val id: Long? = null,
+    val userId: Int,
+    @Column(columnDefinition = "TEXT")
+    var refreshToken: String,
+) : BaseEntity() {
+    fun updateRefreshToken(refreshToken: String) {
+        this.refreshToken = refreshToken
+        this.updatedAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/org/waitforme/backend/enums/AdminAction.kt
+++ b/src/main/kotlin/org/waitforme/backend/enums/AdminAction.kt
@@ -1,0 +1,7 @@
+package org.waitforme.backend.enums
+
+enum class AdminAction {
+    CREATE,
+    MODIFY,
+    DELETE
+}

--- a/src/main/kotlin/org/waitforme/backend/enums/AdminMenuCode.kt
+++ b/src/main/kotlin/org/waitforme/backend/enums/AdminMenuCode.kt
@@ -1,0 +1,5 @@
+package org.waitforme.backend.enums
+
+enum class AdminMenuCode {
+    NOTICE,
+}

--- a/src/main/kotlin/org/waitforme/backend/enums/GenderType.kt
+++ b/src/main/kotlin/org/waitforme/backend/enums/GenderType.kt
@@ -1,0 +1,7 @@
+package org.waitforme.backend.enums
+
+enum class GenderType {
+    FEMALE,
+    MALE,
+    OTHER,
+}

--- a/src/main/kotlin/org/waitforme/backend/enums/Provider.kt
+++ b/src/main/kotlin/org/waitforme/backend/enums/Provider.kt
@@ -1,0 +1,8 @@
+package org.waitforme.backend.enums
+
+enum class Provider {
+    NAVER,
+    KAKAO,
+    GOOGLE,
+    LOCAL, // 로컬 회원가입 시
+}

--- a/src/main/kotlin/org/waitforme/backend/enums/UserRole.kt
+++ b/src/main/kotlin/org/waitforme/backend/enums/UserRole.kt
@@ -1,7 +1,7 @@
 package org.waitforme.backend.enums
 
-enum class UserRole(val role: String) {
-    ADMIN("ROLE_ADMIN"), // 관리자
-    OWNER("ROLE_OWNER"), // 점주
-    USER("ROLE_USER"), // 사용자
+enum class UserRole(val authorities: List<String>) {
+    ADMIN(listOf("ROLE_ADMIN", "ROLE_OWNER", "ROLE_USER")), // 관리자
+    OWNER(listOf("ROLE_OWNER", "ROLE_USER")), // 점주
+    USER(listOf("ROLE_USER")), // 사용자
 }

--- a/src/main/kotlin/org/waitforme/backend/model/LoginUser.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/LoginUser.kt
@@ -1,0 +1,27 @@
+package org.waitforme.backend.model
+
+import org.springframework.security.core.GrantedAuthority
+import org.waitforme.backend.entity.user.User
+import org.waitforme.backend.enums.Provider
+
+class LoginUser(
+    val id: Int,
+    val provider: Provider,
+    val email: String?,
+    val name: String,
+    private val password: String?,
+    private val authorities: Collection<GrantedAuthority>,
+) : org.springframework.security.core.userdetails.User(
+    id.toString(),
+    password,
+    authorities,
+)
+
+fun User.toLoginUser() = LoginUser(
+    id = this.id,
+    provider = provider,
+    email = email,
+    password = password,
+    authorities = authorities,
+    name = name,
+)

--- a/src/main/kotlin/org/waitforme/backend/model/dto/JwtDto.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/dto/JwtDto.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 data class JwtDto(
     val accessToken: TokenDto,
     val refreshToken: TokenDto,
-    val email: String,
+    val account: String,
     val name: String,
 )
 

--- a/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalAuthRequest.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalAuthRequest.kt
@@ -1,6 +1,9 @@
 package org.waitforme.backend.model.request.auth
 
+import javax.validation.constraints.Pattern
+
 data class LocalAuthRequest(
+    @field:Pattern(regexp = "010-[0-9]{3,4}-[0-9]{4}")
     val phoneNumber: String,
     val authText: String? = null,
 )

--- a/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalAuthRequest.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalAuthRequest.kt
@@ -1,0 +1,20 @@
+package org.waitforme.backend.model.request.auth
+
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.waitforme.backend.entity.user.User
+import org.waitforme.backend.enums.Provider
+
+data class LocalAuthRequest(
+    val phoneNumber: String,
+    val name: String, // nickname?
+    val password: String,
+    val isOwner: Boolean,
+)
+
+fun LocalAuthRequest.toUserEntity(encoder: PasswordEncoder, isOwner: Boolean) = User(
+    provider = Provider.LOCAL,
+    phoneNumber = phoneNumber,
+    password = encoder.encode(password),
+    name = name,
+    isOwner = isOwner
+)

--- a/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalAuthRequest.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalAuthRequest.kt
@@ -3,7 +3,7 @@ package org.waitforme.backend.model.request.auth
 import javax.validation.constraints.Pattern
 
 data class LocalAuthRequest(
-    @field:Pattern(regexp = "010-[0-9]{3,4}-[0-9]{4}")
+    @field:Pattern(regexp = "010[0-9]{3,4}[0-9]{4}")
     val phoneNumber: String,
     val authText: String? = null,
 )

--- a/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalRefreshTokenRequest.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalRefreshTokenRequest.kt
@@ -1,0 +1,5 @@
+package org.waitforme.backend.model.request.auth
+
+data class LocalRefreshTokenRequest(
+    val refreshToken: String,
+)

--- a/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalSignInRequest.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalSignInRequest.kt
@@ -1,6 +1,9 @@
 package org.waitforme.backend.model.request.auth
 
+import javax.validation.constraints.Pattern
+
 data class LocalSignInRequest(
+    @field:Pattern(regexp = "010-[0-9]{3,4}-[0-9]{4}")
     val phoneNumber: String,
     val password: String,
 )

--- a/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalSignInRequest.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalSignInRequest.kt
@@ -3,7 +3,7 @@ package org.waitforme.backend.model.request.auth
 import javax.validation.constraints.Pattern
 
 data class LocalSignInRequest(
-    @field:Pattern(regexp = "010-[0-9]{3,4}-[0-9]{4}")
+    @field:Pattern(regexp = "010[0-9]{3,4}[0-9]{4}")
     val phoneNumber: String,
     val password: String,
 )

--- a/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalSignInRequest.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalSignInRequest.kt
@@ -1,6 +1,6 @@
 package org.waitforme.backend.model.request.auth
 
-data class LocalAuthRequest(
+data class LocalSignInRequest(
     val phoneNumber: String,
-    val authText: String? = null,
+    val password: String,
 )

--- a/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalSignUpRequest.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalSignUpRequest.kt
@@ -3,10 +3,17 @@ package org.waitforme.backend.model.request.auth
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.waitforme.backend.entity.user.User
 import org.waitforme.backend.enums.Provider
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
 
 data class LocalSignUpRequest(
+    @field:Pattern(regexp = "010-[0-9]{3,4}-[0-9]{4}")
     val phoneNumber: String,
-    val name: String, // nickname?
+    @NotBlank
+    val name: String,
+    @NotBlank
+    @Size(min = 7, max = 25)
     val password: String,
     val isOwner: Boolean,
 )

--- a/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalSignUpRequest.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalSignUpRequest.kt
@@ -1,0 +1,21 @@
+package org.waitforme.backend.model.request.auth
+
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.waitforme.backend.entity.user.User
+import org.waitforme.backend.enums.Provider
+
+data class LocalSignUpRequest(
+    val phoneNumber: String,
+    val name: String, // nickname?
+    val password: String,
+    val isOwner: Boolean,
+)
+
+fun LocalSignUpRequest.toUserEntity(encoder: PasswordEncoder, isOwner: Boolean, isAuth: Boolean) = User(
+    provider = Provider.LOCAL,
+    phoneNumber = phoneNumber,
+    password = encoder.encode(password),
+    name = name,
+    isOwner = isOwner,
+    isAuth = isAuth
+)

--- a/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalSignUpRequest.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/request/auth/LocalSignUpRequest.kt
@@ -8,14 +8,13 @@ import javax.validation.constraints.Pattern
 import javax.validation.constraints.Size
 
 data class LocalSignUpRequest(
-    @field:Pattern(regexp = "010-[0-9]{3,4}-[0-9]{4}")
+    @field:Pattern(regexp = "010[0-9]{3,4}[0-9]{4}")
     val phoneNumber: String,
     @NotBlank
     val name: String,
     @NotBlank
-    @Size(min = 7, max = 25)
+    @field:Size(min = 7, max = 25)
     val password: String,
-    val isOwner: Boolean,
 )
 
 fun LocalSignUpRequest.toUserEntity(encoder: PasswordEncoder, isOwner: Boolean, isAuth: Boolean) = User(
@@ -24,5 +23,5 @@ fun LocalSignUpRequest.toUserEntity(encoder: PasswordEncoder, isOwner: Boolean, 
     password = encoder.encode(password),
     name = name,
     isOwner = isOwner,
-    isAuth = isAuth
+    isAuth = isAuth,
 )

--- a/src/main/kotlin/org/waitforme/backend/model/request/user/UserInfoRequest.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/request/user/UserInfoRequest.kt
@@ -1,0 +1,13 @@
+package org.waitforme.backend.model.request.user
+
+import org.springframework.http.codec.multipart.FilePart
+import org.waitforme.backend.enums.GenderType
+import java.time.LocalDateTime
+
+data class UserInfoRequest(
+    val id: Int = 0,
+    val name: String,
+    val birthedAt: LocalDateTime? = null,
+    val gender: GenderType? = null,
+    val profileImage: FilePart? = null,
+)

--- a/src/main/kotlin/org/waitforme/backend/model/request/user/UserInfoRequest.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/request/user/UserInfoRequest.kt
@@ -1,11 +1,11 @@
 package org.waitforme.backend.model.request.user
 
 import org.waitforme.backend.enums.GenderType
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 data class UserInfoRequest(
     val name: String,
-    val birthedAt: LocalDateTime? = null,
+    val birthedAt: LocalDate? = null,
     val gender: GenderType? = null,
 //    val profileImage: FilePart? = null,
 )

--- a/src/main/kotlin/org/waitforme/backend/model/request/user/UserInfoRequest.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/request/user/UserInfoRequest.kt
@@ -1,13 +1,11 @@
 package org.waitforme.backend.model.request.user
 
-import org.springframework.http.codec.multipart.FilePart
 import org.waitforme.backend.enums.GenderType
 import java.time.LocalDateTime
 
 data class UserInfoRequest(
-    val id: Int = 0,
     val name: String,
     val birthedAt: LocalDateTime? = null,
     val gender: GenderType? = null,
-    val profileImage: FilePart? = null,
+//    val profileImage: FilePart? = null,
 )

--- a/src/main/kotlin/org/waitforme/backend/model/response/admin/AdminAuthResponse.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/response/admin/AdminAuthResponse.kt
@@ -15,7 +15,7 @@ data class AdminAuthResponse(
 fun JwtDto.toAdminAuthResponse(authority: AdminAuthority) = AdminAuthResponse(
     accessToken = accessToken,
     refreshToken = refreshToken,
-    email = email,
+    email = account,
     name = name,
     authority = authority
 )

--- a/src/main/kotlin/org/waitforme/backend/model/response/auth/AuthResponse.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/response/auth/AuthResponse.kt
@@ -1,0 +1,21 @@
+package org.waitforme.backend.model.response.auth
+
+import org.waitforme.backend.entity.user.User
+import org.waitforme.backend.model.dto.JwtDto
+import org.waitforme.backend.model.dto.TokenDto
+
+data class AuthResponse(
+    val phoneNumber: String,
+    val name: String,
+    val isOwner: Boolean,
+    val accessToken: TokenDto,
+    val refreshToken: TokenDto,
+)
+
+fun User.toUserResponse(token: JwtDto) = AuthResponse(
+    accessToken = token.accessToken,
+    refreshToken = token.refreshToken,
+    phoneNumber = phoneNumber,
+    name = name,
+    isOwner = isOwner,
+)

--- a/src/main/kotlin/org/waitforme/backend/model/response/auth/AuthResponse.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/response/auth/AuthResponse.kt
@@ -8,6 +8,7 @@ data class AuthResponse(
     val phoneNumber: String,
     val name: String,
     val isOwner: Boolean,
+    val isAuth: Boolean,
     val accessToken: TokenDto,
     val refreshToken: TokenDto,
 )
@@ -18,4 +19,5 @@ fun User.toUserResponse(token: JwtDto) = AuthResponse(
     phoneNumber = phoneNumber,
     name = name,
     isOwner = isOwner,
+    isAuth = isAuth
 )

--- a/src/main/kotlin/org/waitforme/backend/model/response/auth/AuthResponse.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/response/auth/AuthResponse.kt
@@ -13,7 +13,7 @@ data class AuthResponse(
     val refreshToken: TokenDto,
 )
 
-fun User.toUserResponse(token: JwtDto) = AuthResponse(
+fun User.toAuthResponse(token: JwtDto) = AuthResponse(
     accessToken = token.accessToken,
     refreshToken = token.refreshToken,
     phoneNumber = phoneNumber,

--- a/src/main/kotlin/org/waitforme/backend/model/response/notice/NoticeSaveResponse.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/response/notice/NoticeSaveResponse.kt
@@ -1,0 +1,5 @@
+package org.waitforme.backend.model.response.notice
+
+data class NoticeSaveResponse(
+    val noticeId: Int
+)

--- a/src/main/kotlin/org/waitforme/backend/model/response/user/UserInfoResponse.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/response/user/UserInfoResponse.kt
@@ -6,7 +6,6 @@ import org.waitforme.backend.enums.Provider
 import java.time.LocalDate
 
 data class UserInfoResponse(
-    val id: Int = 0,
     val provider: Provider,
     val phoneNumber: String,
     var email: String? = null,
@@ -15,12 +14,10 @@ data class UserInfoResponse(
     var gender: GenderType? = null,
     var profileImage: String? = null,
     var isOwner: Boolean = false,
-    var isAuth: Boolean = false, // 인증 여부, sns로 등록 시 자동 인증, local은 회원 가입 시 인증 절차 필요
     var isAdult: Boolean = false,
 )
 
 fun User.toUserInfoResponse() = UserInfoResponse(
-    id = id,
     provider = provider,
     phoneNumber = phoneNumber,
     email = email,
@@ -29,6 +26,5 @@ fun User.toUserInfoResponse() = UserInfoResponse(
     gender = gender,
     profileImage = profileImage,
     isOwner = isOwner,
-    isAuth = isAuth,
     isAdult = isAdult,
 )

--- a/src/main/kotlin/org/waitforme/backend/model/response/user/UserInfoResponse.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/response/user/UserInfoResponse.kt
@@ -1,0 +1,34 @@
+package org.waitforme.backend.model.response.user
+
+import org.waitforme.backend.entity.user.User
+import org.waitforme.backend.enums.GenderType
+import org.waitforme.backend.enums.Provider
+import java.time.LocalDateTime
+
+data class UserInfoResponse(
+    val id: Int = 0,
+    val provider: Provider,
+    val phoneNumber: String,
+    val email: String? = null,
+    val name: String,
+    val birthedAt: LocalDateTime? = null,
+    val gender: GenderType? = null,
+    val profileImage: String? = null,
+    val isOwner: Boolean = false,
+    val isAuth: Boolean = false, // 인증 여부, sns로 등록 시 자동 인증, local은 회원 가입 시 인증 절차 필요
+    val isAdult: Boolean = false,
+)
+
+fun User.toUserInfoResponse() = UserInfoResponse(
+    id = id,
+    provider = provider,
+    phoneNumber = phoneNumber,
+    email = email,
+    name = name,
+    birthedAt = birthedAt,
+    gender = gender,
+    profileImage = profileImage,
+    isOwner = isOwner,
+    isAuth = isAuth,
+    isAdult = isAdult
+)

--- a/src/main/kotlin/org/waitforme/backend/model/response/user/UserInfoResponse.kt
+++ b/src/main/kotlin/org/waitforme/backend/model/response/user/UserInfoResponse.kt
@@ -3,20 +3,20 @@ package org.waitforme.backend.model.response.user
 import org.waitforme.backend.entity.user.User
 import org.waitforme.backend.enums.GenderType
 import org.waitforme.backend.enums.Provider
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 data class UserInfoResponse(
     val id: Int = 0,
     val provider: Provider,
     val phoneNumber: String,
-    val email: String? = null,
-    val name: String,
-    val birthedAt: LocalDateTime? = null,
-    val gender: GenderType? = null,
-    val profileImage: String? = null,
-    val isOwner: Boolean = false,
-    val isAuth: Boolean = false, // 인증 여부, sns로 등록 시 자동 인증, local은 회원 가입 시 인증 절차 필요
-    val isAdult: Boolean = false,
+    var email: String? = null,
+    var name: String,
+    var birthedAt: LocalDate? = null,
+    var gender: GenderType? = null,
+    var profileImage: String? = null,
+    var isOwner: Boolean = false,
+    var isAuth: Boolean = false, // 인증 여부, sns로 등록 시 자동 인증, local은 회원 가입 시 인증 절차 필요
+    var isAdult: Boolean = false,
 )
 
 fun User.toUserInfoResponse() = UserInfoResponse(
@@ -30,5 +30,5 @@ fun User.toUserInfoResponse() = UserInfoResponse(
     profileImage = profileImage,
     isOwner = isOwner,
     isAuth = isAuth,
-    isAdult = isAdult
+    isAdult = isAdult,
 )

--- a/src/main/kotlin/org/waitforme/backend/repository/admin/AdminHistoryRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/admin/AdminHistoryRepository.kt
@@ -1,0 +1,9 @@
+package org.waitforme.backend.repository.admin
+
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+import org.waitforme.backend.entity.admin.AdminHistory
+
+@Repository
+interface AdminHistoryRepository: CrudRepository<AdminHistory, Int> {
+}

--- a/src/main/kotlin/org/waitforme/backend/repository/admin/AdminRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/admin/AdminRepository.kt
@@ -6,5 +6,5 @@ import org.waitforme.backend.entity.admin.Admin
 
 @Repository
 interface AdminRepository : CrudRepository<Admin, Int> {
-    fun findAdminByEmailAndIsDeleted(email: String, isDeleted: Boolean): Admin?
+    fun findAdminByEmail(email: String): Admin?
 }

--- a/src/main/kotlin/org/waitforme/backend/repository/user/UserAuthRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/user/UserAuthRepository.kt
@@ -1,0 +1,11 @@
+package org.waitforme.backend.repository.user
+
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+import org.waitforme.backend.entity.user.UserAuth
+
+@Repository
+interface UserAuthRepository : CrudRepository<UserAuth, Int> {
+
+    fun findByPhoneNumber(phoneNumber: String): UserAuth?
+}

--- a/src/main/kotlin/org/waitforme/backend/repository/user/UserRefreshTokenRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/user/UserRefreshTokenRepository.kt
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Repository
 import org.waitforme.backend.entity.user.UserRefreshToken
 
 @Repository
-interface UserRefreshTokenRepository : CrudRepository<UserRefreshToken, Long> {
-    fun findByUserId(userId: Long): UserRefreshToken?
+interface UserRefreshTokenRepository : CrudRepository<UserRefreshToken, Int> {
     fun findByRefreshToken(refreshToken: String): UserRefreshToken?
 }

--- a/src/main/kotlin/org/waitforme/backend/repository/user/UserRefreshTokenRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/user/UserRefreshTokenRepository.kt
@@ -1,0 +1,11 @@
+package org.waitforme.backend.repository.user
+
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+import org.waitforme.backend.entity.user.UserRefreshToken
+
+@Repository
+interface UserRefreshTokenRepository : CrudRepository<UserRefreshToken, Long> {
+    fun findByUserId(userId: Long): UserRefreshToken?
+    fun findByRefreshToken(refreshToken: String): UserRefreshToken?
+}

--- a/src/main/kotlin/org/waitforme/backend/repository/user/UserRepository.kt
+++ b/src/main/kotlin/org/waitforme/backend/repository/user/UserRepository.kt
@@ -1,0 +1,12 @@
+package org.waitforme.backend.repository.user
+
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+import org.waitforme.backend.entity.user.User
+import org.waitforme.backend.enums.Provider
+
+@Repository
+interface UserRepository : CrudRepository<User, Int> {
+
+    fun findByProviderAndPhoneNumber(provider: Provider, phoneNumber: String): User?
+}

--- a/src/main/kotlin/org/waitforme/backend/service/AdminService.kt
+++ b/src/main/kotlin/org/waitforme/backend/service/AdminService.kt
@@ -39,7 +39,7 @@ class AdminService(
         return createAdminToken(admin).toAdminAuthResponse(authority = admin.authority)
     }
 
-    fun login(request: AdminAuthRequest): AdminAuthResponse {
+    fun signIn(request: AdminAuthRequest): AdminAuthResponse {
         return adminRepository.findAdminByEmail(email = request.email)?.let { admin ->
             if (admin.isDeleted!!) {
                 throw InvalidParameterException("탈퇴 처리된 어드민입니다.")

--- a/src/main/kotlin/org/waitforme/backend/service/AdminService.kt
+++ b/src/main/kotlin/org/waitforme/backend/service/AdminService.kt
@@ -20,8 +20,12 @@ class AdminService(
 ) {
 
     fun signUp(request: AdminAuthRequest): AdminAuthResponse {
-        val admin = adminRepository.findAdminByEmailAndIsDeleted(email = request.email, isDeleted = false)?.let {
-            throw InvalidParameterException("이미 가입된 어드민입니다.") // TODO : 예외 세분화하기
+        val admin = adminRepository.findAdminByEmail(email = request.email)?.let { admin ->
+            if (admin.isDeleted!!) {
+                throw InvalidParameterException("탈퇴 처리된 어드민입니다.")
+            } else {
+                throw InvalidParameterException("이미 가입된 어드민입니다.")
+            }
         } ?: run {
             adminRepository.save(
                 Admin(
@@ -36,10 +40,14 @@ class AdminService(
     }
 
     fun login(request: AdminAuthRequest): AdminAuthResponse {
-        return adminRepository.findAdminByEmailAndIsDeleted(email = request.email, isDeleted = false)?.let { admin ->
-            when (passwordEncoder.matches(request.password, admin.password)) {
-                true -> createAdminToken(admin).toAdminAuthResponse(authority = admin.authority)
-                false -> throw InvalidParameterException("잘못된 비밀번호입니다.")
+        return adminRepository.findAdminByEmail(email = request.email)?.let { admin ->
+            if (admin.isDeleted!!) {
+                throw InvalidParameterException("탈퇴 처리된 어드민입니다.")
+            } else {
+                when (passwordEncoder.matches(request.password, admin.password)) {
+                    true -> createAdminToken(admin).toAdminAuthResponse(authority = admin.authority)
+                    false -> throw InvalidParameterException("잘못된 비밀번호입니다.")
+                }
             }
         } ?: throw InvalidParameterException("유효하지 않은 관리자입니다.")
     }
@@ -47,7 +55,7 @@ class AdminService(
     private fun createAdminToken(admin: Admin) =
         jwtTokenProvider.createJwt(
             id = admin.id,
-            email = admin.email,
+            account = admin.email,
             name = admin.name ?: "",
             role = UserRole.ADMIN,
         )

--- a/src/main/kotlin/org/waitforme/backend/service/AuthService.kt
+++ b/src/main/kotlin/org/waitforme/backend/service/AuthService.kt
@@ -1,0 +1,55 @@
+package org.waitforme.backend.service
+
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
+import org.waitforme.backend.config.security.JwtTokenProvider
+import org.waitforme.backend.enums.Provider
+import org.waitforme.backend.enums.UserRole
+import org.waitforme.backend.model.request.auth.LocalAuthRequest
+import org.waitforme.backend.model.request.auth.toUserEntity
+import org.waitforme.backend.model.response.auth.AuthResponse
+import org.waitforme.backend.model.response.auth.toUserResponse
+import org.waitforme.backend.repository.user.UserRepository
+import javax.security.auth.message.AuthException
+
+@Service
+class AuthService(
+    private val userRepository: UserRepository,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val encoder: PasswordEncoder,
+) {
+
+    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    fun signUpLocal(request: LocalAuthRequest): AuthResponse {
+        userRepository.findByProviderAndPhoneNumber(
+            provider = Provider.LOCAL,
+            phoneNumber = request.phoneNumber,
+        )?.let { user ->
+            throw IllegalArgumentException("이미 등록된 계정입니다.")
+        }
+
+        val user = userRepository.save(request.toUserEntity(encoder, isOwner = false))
+        val token = jwtTokenProvider.createJwt(id = user.id, account = user.phoneNumber, name = user.name, role = UserRole.USER)
+
+        return user.toUserResponse(token)
+    }
+
+    @Transactional
+    fun signInLocal(request: LocalAuthRequest): AuthResponse {
+        val user = userRepository.findByProviderAndPhoneNumber(
+            provider = Provider.LOCAL,
+            phoneNumber = request.phoneNumber
+        ) ?: throw AuthException("존재하지 않는 회원입니다. 회원 가입을 진행해주세요.")
+
+        val token = if (encoder.matches(request.password, user.password)) {
+            user.checkDeletedUser() // 탈퇴 회원인지 체크
+            jwtTokenProvider.createJwt(id = user.id, account = user.phoneNumber, name = user.name, role = UserRole.USER)
+        } else {
+            throw AuthException("비밀번호가 일치하지 않습니다.")
+        }
+
+        return user.toUserResponse(token)
+    }
+}

--- a/src/main/kotlin/org/waitforme/backend/service/AuthService.kt
+++ b/src/main/kotlin/org/waitforme/backend/service/AuthService.kt
@@ -15,7 +15,7 @@ import org.waitforme.backend.model.request.auth.LocalSignInRequest
 import org.waitforme.backend.model.request.auth.LocalSignUpRequest
 import org.waitforme.backend.model.request.auth.toUserEntity
 import org.waitforme.backend.model.response.auth.AuthResponse
-import org.waitforme.backend.model.response.auth.toUserResponse
+import org.waitforme.backend.model.response.auth.toAuthResponse
 import org.waitforme.backend.repository.user.UserAuthRepository
 import org.waitforme.backend.repository.user.UserRefreshTokenRepository
 import org.waitforme.backend.repository.user.UserRepository
@@ -116,7 +116,7 @@ class AuthService(
                         role = UserRole.USER,
                     )
 
-                    user.toUserResponse(token)
+                    user.toAuthResponse(token)
                 } else {
                     throw IllegalArgumentException("인증 유효시간 15분을 초과했습니다. 다시 인증을 시도해주세요.")
                 }
@@ -146,7 +146,7 @@ class AuthService(
             throw AuthException("비밀번호가 일치하지 않습니다.")
         }
 
-        return user.toUserResponse(token)
+        return user.toAuthResponse(token)
     }
 
     @Transactional
@@ -165,11 +165,11 @@ class AuthService(
 
         // token 새로 발급받기
         val token = jwtTokenProvider.createJwt(
-                id = user.id,
-                account = user.phoneNumber,
-                name = user.name,
-                role = UserRole.USER,
-            )
+            id = user.id,
+            account = user.phoneNumber,
+            name = user.name,
+            role = UserRole.USER,
+        )
         userRefreshToken.updateRefreshToken(token.refreshToken.token) // 새로 발급받은 refreshToken을 저장
 
         return token

--- a/src/main/kotlin/org/waitforme/backend/service/AuthService.kt
+++ b/src/main/kotlin/org/waitforme/backend/service/AuthService.kt
@@ -5,47 +5,139 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Transactional
 import org.waitforme.backend.config.security.JwtTokenProvider
+import org.waitforme.backend.entity.user.UserAuth
 import org.waitforme.backend.enums.Provider
 import org.waitforme.backend.enums.UserRole
 import org.waitforme.backend.model.request.auth.LocalAuthRequest
+import org.waitforme.backend.model.request.auth.LocalSignInRequest
+import org.waitforme.backend.model.request.auth.LocalSignUpRequest
 import org.waitforme.backend.model.request.auth.toUserEntity
 import org.waitforme.backend.model.response.auth.AuthResponse
 import org.waitforme.backend.model.response.auth.toUserResponse
+import org.waitforme.backend.repository.user.UserAuthRepository
 import org.waitforme.backend.repository.user.UserRepository
+import java.security.InvalidParameterException
+import java.time.Duration
+import java.time.LocalDateTime
 import javax.security.auth.message.AuthException
 
 @Service
 class AuthService(
     private val userRepository: UserRepository,
+    private val userAuthRepository: UserAuthRepository,
     private val jwtTokenProvider: JwtTokenProvider,
     private val encoder: PasswordEncoder,
 ) {
 
     @Transactional(isolation = Isolation.READ_UNCOMMITTED)
-    fun signUpLocal(request: LocalAuthRequest): AuthResponse {
+    fun requestAuthLocal(request: LocalAuthRequest): Boolean {
         userRepository.findByProviderAndPhoneNumber(
             provider = Provider.LOCAL,
             phoneNumber = request.phoneNumber,
-        )?.let { user ->
-            throw IllegalArgumentException("이미 등록된 계정입니다.")
+        )?.let {
+            if (it.isDeleted || it.deletedAt != null) {
+                throw IllegalArgumentException("탈퇴 처리된 계정은 재가입할 수 없습니다.")
+            }
+
+            throw IllegalArgumentException("이미 등록된 계정입니다. 로그인 해주세요.")
         }
 
-        val user = userRepository.save(request.toUserEntity(encoder, isOwner = false))
-        val token = jwtTokenProvider.createJwt(id = user.id, account = user.phoneNumber, name = user.name, role = UserRole.USER)
+        // 난수 생성하여 인증번호 저장
+        val authText = (100000..999999).random().toString()
 
-        return user.toUserResponse(token)
+        // 이미 요청을 보낸적이 있는지 확인
+        userAuthRepository.findByPhoneNumber(phoneNumber = request.phoneNumber)?.let { userAuth ->
+            val userAuthAt = userAuth.authenticatedAt
+            val userRequestedAt = userAuth.requestedAt
+
+            // 이미 인증이 완료되었는지 확인 - 15분 내로 인증을 받은 회원이어야 함
+            if (userAuthAt != null && Duration.between(LocalDateTime.now(), userAuthAt).toMinutes() < 15) {
+                throw IllegalArgumentException("이미 인증이 완료된 회원입니다. 회원가입을 진행해주세요.")
+            }
+
+            if (Duration.between(LocalDateTime.now(), userRequestedAt).seconds <= 30) {
+                throw IllegalArgumentException("인증 번호 재요청은 요청을 보낸 후 30초 후에 가능합니다.")
+            }
+
+            userAuth.authText = authText
+            userAuth.requestedAt = LocalDateTime.now()
+        } ?: userAuthRepository.save(
+            UserAuth(
+                phoneNumber = request.phoneNumber,
+                authText = authText,
+            ),
+        )
+
+        // TODO : 인증 번호 전송
+
+        // 전송 완료되면 true, 아니면 false
+        return true
+    }
+
+    fun verifyAuthLocal(request: LocalAuthRequest): Boolean {
+        return userAuthRepository.findByPhoneNumber(phoneNumber = request.phoneNumber)?.let { userAuth ->
+            userAuth.authenticatedAt?.let {
+                if (Duration.between(LocalDateTime.now(), userAuth.authenticatedAt).toMinutes() < 15) {
+                    throw IllegalArgumentException("이미 인증이 완료된 회원입니다. 회원가입을 진행해주세요.")
+                } else {
+                    throw IllegalArgumentException("인증 유효시간 15분을 초과했습니다. 다시 인증을 시도해주세요.")
+                }
+            } ?: run {
+                if (Duration.between(userAuth.requestedAt, LocalDateTime.now()).toMinutes() > 2) {
+                    throw InvalidParameterException("인증 허용 시간 2분을 초과하였습니다. 인증 번호를 다시 요청해주세요.")
+                }
+            }
+
+            if (userAuth.authText == request.authText) {
+                userAuth.authenticatedAt = LocalDateTime.now()
+                userAuthRepository.save(userAuth)
+                true
+            } else {
+                false
+            }
+        } ?: throw IllegalArgumentException("인증 정보를 찾을 수 없습니다. 인증을 다시 요청해주세요.")
+    }
+
+    fun signUpLocal(request: LocalSignUpRequest): AuthResponse {
+        return userAuthRepository.findByPhoneNumber(phoneNumber = request.phoneNumber)?.let {
+            // 이미 인증이 완료되었는지 확인 - 15분 내로 인증을 받은 회원이어야 함
+            it.authenticatedAt?.let { userAuthAt ->
+                if (Duration.between(LocalDateTime.now(), userAuthAt).toMinutes() < 15) {
+                    // 인증 완료 시 회원가입 완료
+                    val user = userRepository.save(request.toUserEntity(encoder, isOwner = false, isAuth = true))
+                    val token = jwtTokenProvider.createJwt(
+                        id = user.id,
+                        account = user.phoneNumber,
+                        name = user.name,
+                        role = UserRole.USER,
+                    )
+
+                    user.toUserResponse(token)
+                } else {
+                    throw IllegalArgumentException("인증 유효시간 15분을 초과했습니다. 다시 인증을 시도해주세요.")
+                }
+            }
+        } ?: throw IllegalArgumentException("인증 정보를 찾을 수 없습니다. 인증을 다시 요청해주세요.")
     }
 
     @Transactional
-    fun signInLocal(request: LocalAuthRequest): AuthResponse {
+    fun signInLocal(request: LocalSignInRequest): AuthResponse {
         val user = userRepository.findByProviderAndPhoneNumber(
             provider = Provider.LOCAL,
-            phoneNumber = request.phoneNumber
-        ) ?: throw AuthException("존재하지 않는 회원입니다. 회원 가입을 진행해주세요.")
+            phoneNumber = request.phoneNumber,
+        )?.let { user ->
+            user.checkAuthUser()
+            user.checkDeletedUser()
+            user
+        } ?: throw AuthException("존재하지 않는 회원입니다. 회원 가입을 진행해주세요.")
 
         val token = if (encoder.matches(request.password, user.password)) {
-            user.checkDeletedUser() // 탈퇴 회원인지 체크
-            jwtTokenProvider.createJwt(id = user.id, account = user.phoneNumber, name = user.name, role = UserRole.USER)
+            jwtTokenProvider.createJwt(
+                id = user.id,
+                account = user.phoneNumber,
+                name = user.name,
+                role = UserRole.USER,
+            )
         } else {
             throw AuthException("비밀번호가 일치하지 않습니다.")
         }

--- a/src/main/kotlin/org/waitforme/backend/service/NoticeService.kt
+++ b/src/main/kotlin/org/waitforme/backend/service/NoticeService.kt
@@ -9,10 +9,7 @@ import org.waitforme.backend.enums.AdminMenuCode
 import org.waitforme.backend.model.LoginAdmin
 import org.waitforme.backend.model.request.notice.NoticeRequest
 import org.waitforme.backend.model.request.notice.toNoticeEntity
-import org.waitforme.backend.model.response.notice.NoticeListResponse
-import org.waitforme.backend.model.response.notice.NoticeResponse
-import org.waitforme.backend.model.response.notice.toNoticeListResponse
-import org.waitforme.backend.model.response.notice.toNoticeResponse
+import org.waitforme.backend.model.response.notice.*
 import org.waitforme.backend.repository.admin.AdminHistoryRepository
 import org.waitforme.backend.repository.notice.NoticeRepository
 import org.webjars.NotFoundException
@@ -32,7 +29,7 @@ class NoticeService(
             .toNoticeListResponse()
 
     @Transactional
-    fun saveNotice(noticeId: Int? = null, request: NoticeRequest, loginAdmin: LoginAdmin): Int {
+    fun saveNotice(noticeId: Int? = null, request: NoticeRequest, loginAdmin: LoginAdmin): NoticeSaveResponse {
         val notice = noticeRepository.save(request.toNoticeEntity(id = noticeId))
 
         noticeId?.let {
@@ -55,7 +52,7 @@ class NoticeService(
             )
         }
 
-        return notice.id
+        return NoticeSaveResponse(noticeId = notice.id)
     }
 
     @Transactional

--- a/src/main/kotlin/org/waitforme/backend/service/UserService.kt
+++ b/src/main/kotlin/org/waitforme/backend/service/UserService.kt
@@ -22,8 +22,8 @@ class UserService(
     fun saveUserInfo(userId: Int, request: UserInfoRequest): UserInfoResponse {
         return userRepository.findByIdOrNull(userId)?.apply {
             name = request.name
-            birthedAt = request.birthedAt
-            gender = request.gender
+            request.birthedAt?.let { birthedAt = it }
+            request.gender?.let { gender = it }
     //                profileImage = request.profileImage // TODO : 프로필 이미지 s3 업로드
         }?.run {
             userRepository.save(this)

--- a/src/main/kotlin/org/waitforme/backend/service/UserService.kt
+++ b/src/main/kotlin/org/waitforme/backend/service/UserService.kt
@@ -1,0 +1,32 @@
+package org.waitforme.backend.service
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.waitforme.backend.model.request.user.UserInfoRequest
+import org.waitforme.backend.model.response.user.UserInfoResponse
+import org.waitforme.backend.model.response.user.toUserInfoResponse
+import org.waitforme.backend.repository.user.UserRepository
+import java.security.InvalidParameterException
+
+@Service
+class UserService(
+    private val userRepository: UserRepository,
+) {
+
+    fun getUserInfo(userId: Int): UserInfoResponse {
+        // TODO : 대기 이력 정보 추가
+        return userRepository.findByIdOrNull(userId)?.toUserInfoResponse()
+            ?: throw InvalidParameterException("해당 유저에 대한 정보를 찾을 수 없습니다.")
+    }
+
+    fun saveUserInfo(userId: Int, request: UserInfoRequest): UserInfoResponse {
+        return userRepository.findByIdOrNull(userId)?.apply {
+            name = request.name
+            birthedAt = request.birthedAt
+            gender = request.gender
+    //                profileImage = request.profileImage // TODO : 프로필 이미지 s3 업로드
+        }?.run {
+            userRepository.save(this)
+        }?.toUserInfoResponse() ?: throw InvalidParameterException("해당 유저에 대한 정보를 찾을 수 없습니다.")
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,12 @@ jwt:
   token-secret-key: ThisIsTempSecretKeyWaitForMeThisIsTempSecretKeyWaitForMeThisIsTempSecretKeyWaitForMe
   access-token-valid-time: 1800000   # 30분
   refresh-token-valid-time: 3600000
+
+sms:
+  fromNumber: 01012345678
+  apiKey: api-key
+  apiSecretKey: api-secret-key
+
+totp:
+  secret: ThisIsTempSecretKeyWaitForMeThisIsTempSecretKeyWaitForMeThisIsTempSecretKeyWaitForMe
+  validTime: 120000      # ms 기준


### PR DESCRIPTION
### 📍 체크 리스트

- [ ] 리뷰어를 설정했습니다.
- [ ] 블로킹 이슈가 있습니다. (`확인해야 할 부분`에 상세 설명 첨부)

### 🧱 구현 내용

- 로컬 문자인증 요청/확인 API 추가
  - 문자인증 API는 한도제한 이슈로 보류
- 로컬 회원가입/로그인 API 추가
- 내정보 조회/수정 API 추가
- 어드민 히스토리 로직 추가
- ROLE 위계 설정 (ADMIN > OWNER > USER)
- 공지/어드민 피드백 반영 수정

### 🚨 확인해야 할 부분

- 문자인증 및 회원가입 플로우 설계
- 문자인증 API는 한도제한 이슈 해결 후 추후 구현 필요
